### PR TITLE
Add support for v1-style processes `or`, `and`, ..., `sum`, `add`, `divide`, ...

### DIFF
--- a/openeo-geotrellis/src/test/java/org/openeo/geotrellis/TestOpenEOProcessScriptBuilder.java
+++ b/openeo-geotrellis/src/test/java/org/openeo/geotrellis/TestOpenEOProcessScriptBuilder.java
@@ -10,248 +10,484 @@ import scala.collection.Seq;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestOpenEOProcessScriptBuilder {
 
-    @DisplayName("Test NDVI process graph")
-    @Test
-    public void testNDVIScript() {
-        OpenEOProcessScriptBuilder builder = createNormalizedDifferenceProcess();
+    private void testNdvi(OpenEOProcessScriptBuilder builder) {
         Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        ByteArrayTile tile1 = ByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-        ByteArrayTile tile2 = ByteConstantNoDataArrayTile.fill((byte) 5, 4, 4);
+        DoubleArrayTile tile1 = fillDoubleArrayTile(4, 2, 3, 10, 6, 3, 9, 15, 0, Double.NaN);
+        DoubleArrayTile tile2 = fillDoubleArrayTile(4, 2, 0, 6, 10, 9, 7, 17, 0, Double.NaN);
         Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1, tile2)));
+        assertEquals(1, result.length());
         Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toArrayDouble()));
-        assertEquals(3.0, ndvi.get(0, 0));
+        assertDoubleTileEquals(fillDoubleArrayTile(4, 2, 1.0, 0.25, -0.25, -0.5, 0.125, -0.0625, Double.NaN, Double.NaN), ndvi);
     }
 
-    @DisplayName("Test NDVI process graph with band selection")
-    @Test
-    public void testNDVIScriptBandSelection() {
-        OpenEOProcessScriptBuilder builder = createNormalizedDifferenceProcess2();
-        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        ByteArrayTile tile1 = ByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-        ByteArrayTile tile2 = ByteConstantNoDataArrayTile.fill((byte) 5, 4, 4);
-        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1, tile2)));
-        Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toArrayDouble()));
-        assertEquals(3.0, ndvi.get(0, 0));
-    }
-
-    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcess() {
+    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcessLegacy() {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
         Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("divide", empty);
-
+        builder.expressionStart("divide", dummyMap("data"));
         builder.arrayStart("data");
 
-        builder.expressionStart("sum", empty);
+        builder.expressionStart("subtract", dummyMap("data"));
         builder.argumentStart("data");
         builder.argumentEnd();
-        builder.expressionEnd("sum",empty);
+        builder.expressionEnd("subtract", dummyMap("data"));
         builder.arrayElementDone();
 
-        builder.expressionStart("subtract", empty);
+        builder.expressionStart("sum", dummyMap("data"));
         builder.argumentStart("data");
         builder.argumentEnd();
-        builder.expressionEnd("subtract",empty);
+        builder.expressionEnd("sum", dummyMap("data"));
         builder.arrayElementDone();
 
         builder.arrayEnd();
-
-        builder.expressionEnd("divide", empty);
+        builder.expressionEnd("divide", dummyMap("data"));
         return builder;
+    }
+
+    @DisplayName("Test NDVI legacy style")
+    @Test
+    public void testNdviLegacy() {
+        testNdvi(createNormalizedDifferenceProcessLegacy());
     }
 
     /**
-     * This normalized difference process actually selects bands from the array using array_element
-     * @return
+     * NDVI implementation with "sum(data)", "subtract(data)" and "divide(data)" (API 0.4 style)
      */
-    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcess2() {
+    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcess04DataArrays() {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
         Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("divide", empty);
-
+        builder.expressionStart("divide", dummyMap("data"));
         builder.arrayStart("data");
 
-        builder.expressionStart("sum", empty);
-        specifyBands(builder);
-        builder.expressionEnd("sum",empty);
+        builder.expressionStart("subtract", dummyMap("data"));
+        buildBandArray(builder, "data");
+        builder.expressionEnd("subtract", dummyMap("data"));
         builder.arrayElementDone();
 
-        builder.expressionStart("subtract", empty);
-        specifyBands(builder);
-        builder.expressionEnd("subtract",empty);
+        builder.expressionStart("sum", dummyMap("data"));
+        buildBandArray(builder, "data");
+        builder.expressionEnd("sum", dummyMap("data"));
         builder.arrayElementDone();
 
         builder.arrayEnd();
-
-        builder.expressionEnd("divide", empty);
+        builder.expressionEnd("divide", dummyMap("data"));
         return builder;
     }
 
-    private static void specifyBands(OpenEOProcessScriptBuilder builder) {
-        builder.arrayStart("data");
+    @DisplayName("Test NDVI 0.4-style with 'sum/subtract/divide(data)'")
+    @Test
+    public void testNDVI04DataArrays() {
+        testNdvi(createNormalizedDifferenceProcess04DataArrays());
+    }
 
-        Map<String, Object> args = Collections.singletonMap("index", 0);
-        builder.expressionStart("array_element", args);
-        builder.constantArgument("index",0);
-        builder.argumentStart("data");
+    /**
+     * NDVI implementation with "add(x,y)", "subtract(x,y)" and "divide(x,y)" (API 1.0 style)
+     */
+    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcess10AddXY() {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        Map<String, Object> empty = Collections.emptyMap();
+        builder.expressionStart("divide", dummyMap("x", "y"));
+
+        builder.argumentStart("x");
+        builder.expressionStart("subtract", dummyMap("x", "y"));
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd("subtract", dummyMap("x", "y"));
         builder.argumentEnd();
-        builder.expressionEnd("array_element",args);
-        builder.arrayElementDone();
 
-        args = Collections.singletonMap("index", 1);
-        builder.expressionStart("array_element",args);
-        builder.constantArgument("index",1);
-        builder.argumentStart("data");
+        builder.argumentStart("y");
+        builder.expressionStart("add", dummyMap("x", "y"));
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd("add", dummyMap("x", "y"));
         builder.argumentEnd();
-        builder.expressionEnd("array_element",args);
-        builder.arrayElementDone();
 
-        builder.arrayEnd();
+        builder.expressionEnd("divide", dummyMap("x", "y"));
+        return builder;
+    }
+
+    @DisplayName("Test NDVI 1.0-style with 'add(x,y)'")
+    @Test
+    public void testNdvi10AddXY() {
+        testNdvi(createNormalizedDifferenceProcess10AddXY());
+    }
+
+    /**
+     * NDVI implementation with "sum(data)", "subtract(x,y)" and "divide(x,y)" (API 1.0 style)
+     */
+    static OpenEOProcessScriptBuilder createNormalizedDifferenceProcess10SumData() {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        Map<String, Object> empty = Collections.emptyMap();
+        builder.expressionStart("divide", dummyMap("x", "y"));
+
+        builder.argumentStart("x");
+        builder.expressionStart("subtract", dummyMap("x", "y"));
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd("subtract", dummyMap("x", "y"));
+        builder.argumentEnd();
+
+        builder.argumentStart("y");
+        builder.expressionStart("sum", dummyMap("data"));
+        buildBandArray(builder, "data");
+        builder.expressionEnd("sum", dummyMap("data"));
+        builder.argumentEnd();
+
+        builder.expressionEnd("divide", dummyMap("x", "y"));
+        return builder;
+    }
+
+    @DisplayName("Test NDVI 1.0-style with 'sum(data)'")
+    @Test
+    public void testNDVI10SumData() {
+        testNdvi(createNormalizedDifferenceProcess10SumData());
     }
 
     @DisplayName("Test add constant")
     @Test
     public void testAddConstant() {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("sum", empty);
-
+        Map<String, Object> args = dummyMap("data");
+        builder.expressionStart("sum", args);
         builder.arrayStart("data");
         builder.constantArrayElement(10);
         builder.constantArrayElement(20);
         builder.arrayEnd();
-
-        builder.expressionEnd("sum",empty);
-
+        builder.expressionEnd("sum", args);
 
         Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        ByteArrayTile tile1 = ByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-        ByteArrayTile tile2 = ByteConstantNoDataArrayTile.fill((byte) 5, 4, 4);
+        ByteArrayTile tile1 = fillByteArrayTile(3, 3, 9, 10, 11, 12);
+        ByteArrayTile tile2 = fillByteArrayTile(3, 3, 5, 6, 7, 8);
         Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1, tile2)));
-        Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toArrayDouble()));
-        assertEquals(30.0, ndvi.get(0, 0));
+        Tile res = result.apply(0);
+        assertTileEquals(fillIntArrayTile(3, 3, 30, 30, 30, 30, 30, 30, 30, 30, 30), res);
     }
 
-    @DisplayName("Test logical Or")
-    @Test
-    public void testLogicalOr() {
+    private void testLogicalComparisonWithConstant(String operator, int... expectedValues) {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("or", empty);
-        //not specifying expressions means that we're working on the input coming from the tiles?
-        //see https://github.com/Open-EO/openeo-processes/issues/87#issuecomment-559448790
-        builder.expressionEnd("or",empty);
-
-        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        Tile tile1 = BitArrayTile.fill(true, 4, 4);
-        Tile tile2 = BitArrayTile.fill(false, 4, 4);
-
-        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1,tile2)));
-        Tile merged = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(merged.toBytes()));
-        assertEquals(1, merged.get(0, 0));
-    }
-
-    @DisplayName("Test logical operations")
-    @Test
-    public void testLogicalEquals() {
-        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("eq", empty);
+        Map<String, Object> args = dummyMap("x", "y");
+        builder.expressionStart(operator, args);
         builder.argumentStart("x");
         builder.argumentEnd();
-        builder.constantArgument("y",(byte)10);
-        builder.expressionEnd("eq",empty);
-
+        builder.constantArgument("y", 10);
+        builder.expressionEnd(operator, args);
 
         Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        Tile tile1 = UByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-
-        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1)));
-        Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toBytes()));
-        assertEquals(1, ndvi.get(0, 0));
+        Tile tile = fillByteArrayTile(4, 3, 8, 9, 10, 11, 12);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile)));
+        assertEquals(1, result.length());
+        Tile res = result.apply(0);
+        assertTileEquals(fillBitArrayTile(4, 3, expectedValues), res);
     }
 
-    @DisplayName("Test logical operations: not after equals")
+    @DisplayName("Test logical 'eq' with constant")
     @Test
-    public void testLogicalNot() {
+    public void testLogicalEqWithConstant() {
+        testLogicalComparisonWithConstant("eq", 0, 0, 1, 0, 0);
+    }
+
+    @DisplayName("Test logical 'neq' with constant")
+    @Test
+    public void testLogicalNeqWithConstant() {
+        testLogicalComparisonWithConstant("neq", 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'gt' with constant")
+    @Test
+    public void testLogicalGtWithConstant() {
+        testLogicalComparisonWithConstant("gt", 0, 0, 0, 1, 1);
+    }
+
+    @DisplayName("Test logical 'gte' with constant")
+    @Test
+    public void testLogicalGteWithConstant() {
+        testLogicalComparisonWithConstant("gte", 0, 0, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'lt' with constant")
+    @Test
+    public void testLogicalLtWithConstant() {
+        testLogicalComparisonWithConstant("lt", 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'lte' with constant")
+    @Test
+    public void testLogicalLteWithConstant() {
+        testLogicalComparisonWithConstant("lte", 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1);
+    }
+
+    private void testLogicalComparisonXY(String operator, int... expectedValues) {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("not", empty);
+        Map<String, Object> args = dummyMap("x", "y");
+        builder.expressionStart(operator, args);
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd(operator, args);
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+        Tile tile0 = fillByteArrayTile(3, 2, 8, 9, 10, 11, 12, 13);
+        Tile tile1 = fillByteArrayTile(3, 2, 7, 9, 11, 9, 7, 5);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile0, tile1)));
+        assertEquals(1, result.length());
+        Tile res = result.apply(0);
+        assertTileEquals(fillBitArrayTile(3, 2, expectedValues), res);
+    }
+
+    @DisplayName("Test logical 'eq' between bands")
+    @Test
+    public void testLogicalEqXY() {
+        testLogicalComparisonXY("eq", 0, 1, 0, 0, 0, 0);
+    }
+
+    @DisplayName("Test logical 'neq' between bands")
+    @Test
+    public void testLogicalNeqXY() {
+        testLogicalComparisonXY("neq", 1, 0, 1, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'gt' between bands")
+    @Test
+    public void testLogicalGtXY() {
+        testLogicalComparisonXY("gt", 1, 0, 0, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'gte' between bands")
+    @Test
+    public void testLogicalGteXY() {
+        testLogicalComparisonXY("gte", 1, 1, 0, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'lt' between bands")
+    @Test
+    public void testLogicalLtXY() {
+        testLogicalComparisonXY("lt", 0, 0, 1, 0, 0, 0);
+    }
+
+    @DisplayName("Test logical 'lte' between bands")
+    @Test
+    public void testLogicalLteXY() {
+        testLogicalComparisonXY("lte", 0, 1, 1, 0, 0, 0);
+    }
+
+
+    @DisplayName("Test logical operations: 'not' after 'equals' (legacy)")
+    @Test
+    public void testLogicalNotEqWithExpression() {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        builder.expressionStart("not", dummyMap("expression"));
         builder.argumentStart("expression");
-        builder.expressionStart("eq", empty);
+        builder.expressionStart("eq", dummyMap("x", "y"));
         builder.argumentStart("x");
         builder.argumentEnd();
-        builder.constantArgument("y",(byte)10);
-        builder.expressionEnd("eq",empty);
+        builder.constantArgument("y", (byte) 10);
+        builder.expressionEnd("eq", dummyMap("x", "y"));
         builder.argumentEnd();
-        builder.expressionEnd("not",empty);
-
+        builder.expressionEnd("not", dummyMap("expression"));
 
         Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        Tile tile1 = UByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-
+        Tile tile1 = fillByteArrayTile(4, 3, 8, 9, 10, 11, 12);
         Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1)));
-        Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toBytes()));
-        assertEquals(0, ndvi.get(0, 0));
+        Tile res = result.apply(0);
+        assertTileEquals(fillBitArrayTile(4, 3, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1), res);
     }
+
+    @DisplayName("Test logical operations: 'not' after 'equals'")
+    @Test
+    public void testLogicalNotEqWithX() {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        builder.expressionStart("not", dummyMap("x"));
+        builder.argumentStart("x");
+        builder.expressionStart("eq", dummyMap("x", "y"));
+        builder.argumentStart("x");
+        builder.argumentEnd();
+        builder.constantArgument("y", (byte) 10);
+        builder.expressionEnd("eq", dummyMap("x", "y"));
+        builder.argumentEnd();
+        builder.expressionEnd("not", dummyMap("x"));
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+        Tile tile1 = fillByteArrayTile(4, 3, 8, 9, 10, 11, 12);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1)));
+        Tile res = result.apply(0);
+        assertTileEquals(fillBitArrayTile(4, 3, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1), res);
+    }
+
+    private void testLogicalOperatorWithExpressionsArray(String operator, int... expectedValues) {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        Map<String, Object> args = dummyMap("expressions");
+        builder.expressionStart(operator, args);
+        buildBandArray(builder, "expressions");
+        builder.expressionEnd(operator, args);
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+
+        BitArrayTile x = fillBitArrayTile(4, 4, 0, 0, 1, 1);
+        BitArrayTile y = fillBitArrayTile(4, 4, 0, 1, 0, 1);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(x, y)));
+        assertEquals(1, result.length());
+        Tile z = result.apply(0);
+        assertEquals("bool", z.cellType().toString());
+        assertTileEquals(fillBitArrayTile(4, 4, expectedValues), z);
+    }
+
+    @DisplayName("Test logical 'or' with 'expressions' (legacy)")
+    @Test
+    public void testLogicalOrWithExpressions() {
+        testLogicalOperatorWithExpressionsArray("or", 0, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'and' with 'expressions' (legacy)")
+    @Test
+    public void testLogicalAndWithExpressions() {
+        testLogicalOperatorWithExpressionsArray("and", 0, 0, 0, 1);
+    }
+
+    @DisplayName("Test logical 'xor' with 'expressions' (legacy)")
+    @Test
+    public void testLogicalXorWithExpressions() {
+        testLogicalOperatorWithExpressionsArray("xor", 0, 1, 1, 0);
+    }
+
+    private void testLogicalOperatorWithXY(String operator, int... expectedValues) {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        Map<String, Object> args = new HashMap<String, Object>();
+        args.put("x", "dummy");
+        args.put("y", "dummy");
+        builder.expressionStart(operator, args);
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd(operator, args);
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+
+        BitArrayTile x = fillBitArrayTile(4, 4, 0, 0, 1, 1);
+        BitArrayTile y = fillBitArrayTile(4, 4, 0, 1, 0, 1);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(x, y)));
+        assertEquals(1, result.length());
+        Tile z = result.apply(0);
+        assertEquals("bool", z.cellType().toString());
+        assertTileEquals(fillBitArrayTile(4, 4, expectedValues), z);
+    }
+
+    @DisplayName("Test logical 'or' with 'x' and 'y'")
+    @Test
+    public void testLogicalOrWithXY() {
+        testLogicalOperatorWithXY("or", 0, 1, 1, 1);
+    }
+
+    @DisplayName("Test logical 'and' with 'x' and 'y'")
+    @Test
+    public void testLogicalAndWithXY() {
+        testLogicalOperatorWithXY("and", 0, 0, 0, 1);
+    }
+
+    @DisplayName("Test logical 'xor' with 'x' and 'y'")
+    @Test
+    public void testLogicalXorWithXY() {
+        testLogicalOperatorWithXY("xor", 0, 1, 1, 0);
+    }
+
+    private void testMathXY(String operator, int... expectedValues) {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        builder.expressionStart(operator, dummyMap("x", "y"));
+        buildBandXYArguments(builder, 0, 1);
+        builder.expressionEnd(operator, dummyMap("x", "y"));
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+        Tile tile0 = fillIntArrayTile(3, 2, 3, 4, 5, 6, 7, 8);
+        Tile tile1 = fillIntArrayTile(3, 2, 1, 2, 4, 8, 16, 20);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile0, tile1)));
+        assertEquals(1, result.length());
+        Tile res = result.apply(0);
+        assertTileEquals(fillIntArrayTile(3, 2, expectedValues), res);
+    }
+
+    @DisplayName("Test math 'add(x,y)'")
+    @Test
+    public void testMathAddXY() {
+        testMathXY("add", 4, 6, 9, 14, 23, 28);
+    }
+
+    @DisplayName("Test math 'subtract(x,y)'")
+    @Test
+    public void testMathSubtractXY() {
+        testMathXY("subtract", 2, 2, 1, -2, -9, -12);
+    }
+
+    @DisplayName("Test math 'multiply(x,y)'")
+    @Test
+    public void testMultiplyXY() {
+        testMathXY("multiply", 3, 8, 20, 48, 112, 160);
+    }
+
+    @DisplayName("Test math 'divide(x,y)'")
+    @Test
+    public void testDivideXY() {
+        testMathXY("divide", 3, 2, 1, 0, 0, 0);
+    }
+
+
+    private void testMathData(String operator, int... expectedValues) {
+        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
+        builder.expressionStart(operator, dummyMap("data"));
+        buildBandArray(builder, "data");
+        builder.expressionEnd(operator, dummyMap("data"));
+
+        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
+        Tile tile0 = fillIntArrayTile(3, 2, 3, 4, 5, 6, 7, 8);
+        Tile tile1 = fillIntArrayTile(3, 2, 1, 2, 4, 8, 16, 20);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile0, tile1)));
+        assertEquals(1, result.length());
+        Tile res = result.apply(0);
+        assertTileEquals(fillIntArrayTile(3, 2, expectedValues), res);
+    }
+
+    @DisplayName("Test math 'sum(data)'")
+    @Test
+    public void testMathSumData() {
+        testMathData("sum", 4, 6, 9, 14, 23, 28);
+    }
+
+    @DisplayName("Test math 'subtract(data)'")
+    @Test
+    public void testMathSubtractData() {
+        testMathData("subtract", 2, 2, 1, -2, -9, -12);
+    }
+
+    @DisplayName("Test math 'multiply(data)'")
+    @Test
+    public void testMultiplyData() {
+        testMathData("multiply", 3, 8, 20, 48, 112, 160);
+    }
+
+    @DisplayName("Test math 'product(data)'")
+    @Test
+    public void testProductData() {
+        testMathData("product", 3, 8, 20, 48, 112, 160);
+    }
+
+    @DisplayName("Test math 'divide(data)'")
+    @Test
+    public void testDivideData() {
+        testMathData("divide", 3, 2, 1, 0, 0, 0);
+    }
+
 
     @DisplayName("Test proper error handling in case argument is missing.")
     @Test
     public void testException() {
         OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("not", empty);
-        builder.argumentStart("expression");
-        builder.expressionStart("eq", empty);
+        builder.expressionStart("not", dummyMap("x"));
+        builder.argumentStart("x");
+        builder.expressionStart("eq", dummyMap("x", "y"));
         //builder.argumentStart("x");
         //builder.argumentEnd();
-
         builder.constantArgument("y",(byte)10);
 
         assertThrows(IllegalArgumentException.class,() -> {
-            builder.expressionEnd("eq", empty);
+            builder.expressionEnd("eq", dummyMap("x", "y"));
         });
-
-    }
-
-    @DisplayName("Test logical equals, not equal constant")
-    @Test
-    public void testLogicalEquals2() {
-        OpenEOProcessScriptBuilder builder = new OpenEOProcessScriptBuilder();
-        Map<String, Object> empty = Collections.emptyMap();
-        builder.expressionStart("eq", empty);
-        builder.argumentStart("x");
-        builder.argumentEnd();
-        builder.constantArgument("y",(byte)11);
-        builder.expressionEnd("eq",empty);
-
-
-        Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        Tile tile1 = UByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-
-        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1)));
-        Tile ndvi = result.apply(0);
-
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toBytes()));
-        assertEquals(0, ndvi.get(0, 0));
     }
 
     @DisplayName("Test array_element process")
@@ -268,14 +504,97 @@ public class TestOpenEOProcessScriptBuilder {
 
         builder.expressionEnd("array_element",arguments);
 
-
         Function1<Seq<Tile>, Seq<Tile>> transformation = builder.generateFunction();
-        ByteArrayTile tile1 = ByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
-        ByteArrayTile tile2 = ByteConstantNoDataArrayTile.fill((byte) 5, 4, 4);
-        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile1, tile2)));
-        Tile ndvi = result.apply(0);
+        ByteArrayTile tile0 = ByteConstantNoDataArrayTile.fill((byte) 10, 4, 4);
+        ByteArrayTile tile1 = ByteConstantNoDataArrayTile.fill((byte) 5, 4, 4);
+        Seq<Tile> result = transformation.apply(JavaConversions.asScalaBuffer(Arrays.asList(tile0, tile1)));
+        Tile res = result.apply(0);
+        assertTileEquals(tile1, res);
+    }
 
-        System.out.println("Arrays.toString(ndvi.toArrayDouble()) = " + Arrays.toString(ndvi.toArrayDouble()));
-        assertEquals(5, ndvi.get(0, 0));
+
+    private static void buildArrayElementProcess(OpenEOProcessScriptBuilder builder, Integer index) {
+        Map<String, Object> args = Collections.singletonMap("index", index);
+        builder.expressionStart("array_element", args);
+        builder.constantArgument("index", index);
+        builder.argumentStart("data");
+        builder.argumentEnd();
+        builder.expressionEnd("array_element", args);
+    }
+
+    private static void buildBandArray(OpenEOProcessScriptBuilder builder, String argName) {
+        builder.arrayStart(argName);
+        buildArrayElementProcess(builder, 0);
+        builder.arrayElementDone();
+        buildArrayElementProcess(builder, 1);
+        builder.arrayElementDone();
+        builder.arrayEnd();
+    }
+
+    private static void buildBandXYArguments(OpenEOProcessScriptBuilder builder, Integer xIndex, Integer yIndex) {
+        builder.argumentStart("x");
+        buildArrayElementProcess(builder, xIndex);
+        builder.argumentEnd();
+        builder.argumentStart("y");
+        buildArrayElementProcess(builder, yIndex);
+        builder.argumentEnd();
+    }
+
+    private static BitArrayTile fillBitArrayTile(int cols, int rows, int... values) {
+        BitArrayTile tile = BitArrayTile.ofDim(cols, rows);
+        for (int i = 0; i < Math.min(cols * rows, values.length); i++) {
+            tile.set(i % cols, i / cols, values[i] == 0 ? 0 : 1);
+        }
+        return tile;
+    }
+
+    private static ByteArrayTile fillByteArrayTile(int cols, int rows, int... values) {
+        ByteArrayTile tile = ByteArrayTile.ofDim(cols, rows);
+        for (int i = 0; i < Math.min(cols * rows, values.length); i++) {
+            tile.set(i % cols, i / cols, values[i]);
+        }
+        return tile;
+    }
+
+    private static IntArrayTile fillIntArrayTile(int cols, int rows, int... values) {
+        IntArrayTile tile = IntArrayTile.ofDim(cols, rows);
+        for (int i = 0; i < Math.min(cols * rows, values.length); i++) {
+            tile.set(i % cols, i / cols, values[i]);
+        }
+        return tile;
+    }
+
+    private static DoubleArrayTile fillDoubleArrayTile(int cols, int rows, double... values) {
+        DoubleArrayTile tile = DoubleArrayTile.ofDim(cols, rows);
+        for (int i = 0; i < Math.min(cols * rows, values.length); i++) {
+            tile.setDouble(i % cols, i / cols, values[i]);
+        }
+        return tile;
+    }
+
+    private static Map<String, Object> dummyMap(String... keys) {
+        Map<String, Object> m = new HashMap<String, Object>();
+        for (String key : keys) {
+            m.put(key, "dummy");
+        }
+        return m;
+    }
+
+    private void assertTileEquals(Tile expected, Tile actual) {
+        System.out.println("Expected: " + expected.cols() + "x" + expected.rows() + " " + expected.cellType() + " " + Arrays.toString(expected.toArray()));
+        System.out.println("Actual:   " + actual.cols() + "x" + actual.rows() + " " + actual.cellType() + " " + Arrays.toString(actual.toArray()));
+        assertEquals(expected.cols(), actual.cols());
+        assertEquals(expected.rows(), actual.rows());
+        assertEquals(expected.cellType(), actual.cellType());
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    private void assertDoubleTileEquals(Tile expected, Tile actual) {
+        System.out.println("Expected: " + expected.cols() + "x" + expected.rows() + " " + expected.cellType() + " " + Arrays.toString(expected.toArrayDouble()));
+        System.out.println("Actual:   " + actual.cols() + "x" + actual.rows() + " " + actual.cellType() + " " + Arrays.toString(actual.toArrayDouble()));
+        assertEquals(expected.cols(), actual.cols());
+        assertEquals(expected.rows(), actual.rows());
+        assertEquals(expected.cellType(), actual.cellType());
+        assertArrayEquals(expected.toArray(), actual.toArray());
     }
 }

--- a/openeo-geotrellis/src/test/java/org/openeo/geotrellis/TestOpenEOProcesses.java
+++ b/openeo-geotrellis/src/test/java/org/openeo/geotrellis/TestOpenEOProcesses.java
@@ -62,18 +62,17 @@ public class TestOpenEOProcesses {
     @DisplayName("Test combining all bands.")
     @Test
     public void testMapBands() {
-        OpenEOProcessScriptBuilder processBuilder = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess();
-        Tile tile10 = new ByteConstantTile((byte)10,256,256, (ByteCells) CellType$.MODULE$.fromName("int8raw"));
-        Tile tile5 = new ByteConstantTile((byte)5,256,256, (ByteCells) CellType$.MODULE$.fromName("int8raw"));
-        RDD<Tuple2<SpatialKey, MultibandTile>> datacube = TileLayerRDDBuilders$.MODULE$.createMultibandTileLayerRDD(SparkContext.getOrCreate(), new ArrayMultibandTile(new Tile[]{tile10,tile5}), new TileLayout(1, 1, 256, 256));
+        OpenEOProcessScriptBuilder processBuilder = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess10AddXY();
+        Tile tile0 = new DoubleConstantTile(3.0,256,256, (DoubleCells) CellType$.MODULE$.fromName("float64"));
+        Tile tile1 = new DoubleConstantTile(1.0,256,256, (DoubleCells) CellType$.MODULE$.fromName("float64"));
+        RDD<Tuple2<SpatialKey, MultibandTile>> datacube = TileLayerRDDBuilders$.MODULE$.createMultibandTileLayerRDD(SparkContext.getOrCreate(), new ArrayMultibandTile(new Tile[]{tile0,tile1}), new TileLayout(1, 1, 256, 256));
         ClassTag<SpatialKey> tag = scala.reflect.ClassTag$.MODULE$.apply(SpatialKey.class);
         RDD<Tuple2<SpatialKey, MultibandTile>> ndviDatacube = new OpenEOProcesses().<SpatialKey>mapBandsGeneric(datacube, processBuilder,tag);
         List<Tuple2<SpatialKey, MultibandTile>> result = ndviDatacube.toJavaRDD().collect();
         System.out.println("result = " + result);
-        double[] doubles = result.get(0)._2().band(0).toArrayDouble();
         assertEquals(1, result.get(0)._2().bandCount());
-
-        assertEquals(3.0,doubles[0],0.0);
+        double[] doubles = result.get(0)._2().band(0).toArrayDouble();
+        assertEquals(0.5,doubles[0],0.0);
     }
 
     @Test

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ComputeStatsGeotrellisAdapterTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ComputeStatsGeotrellisAdapterTest.scala
@@ -417,7 +417,7 @@ class ComputeStatsGeotrellisAdapterTest(threshold:Int) {
     val datacube= accumuloDataCube("CGS_SENTINEL2_RADIOMETRY_V102_EARLY", minDateString, maxDateString, polygons.extent, "EPSG:4326")
 
     val selectedBands = datacube.withContext(_.mapValues(_.subsetBands(1,3)))
-    val ndviProcess = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess
+    val ndviProcess = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess10AddXY
     val ndviDataCube = new OpenEOProcesses().mapBandsGeneric(selectedBands, ndviProcess)
 
     assertMedianComputedCorrectly(ndviDataCube, minDateString, minDate, maxDate, polygons)
@@ -523,7 +523,7 @@ class ComputeStatsGeotrellisAdapterTest(threshold:Int) {
     val datacube= accumuloDataCube("CGS_SENTINEL2_RADIOMETRY_V102_EARLY", minDateString, maxDateString, polygons.extent, "EPSG:4326")
 
     val selectedBands = datacube.withContext(_.mapValues(_.subsetBands(1,3))).convert(DoubleConstantNoDataCellType)
-    val ndviProcess = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess
+    val ndviProcess = TestOpenEOProcessScriptBuilder.createNormalizedDifferenceProcess10AddXY
     val processes = new OpenEOProcesses()
     val ndviDataCube = processes.mapBandsGeneric(selectedBands, ndviProcess)//.withContext(_.mapValues(_.mapDouble(0)(pixel => 0.1)))
 


### PR DESCRIPTION
v0.4 defines most processes like `or`, `and`, `sum`, `divide` as "reduce" style processes, which is bit weird (especially for subtract and divide)

v1.0 improves that by defining logical processes, `subtract`, `divide` as "xy" processes, and adds `add` `multiply` as "xy" processes.

This PR makes sure we support both approaches properly (based on the provided arguments: `expressions` or `data` or `x`/`y`?)


largest part of diff of this PR are unit tests (more coverage, more code reuse, deeper asserts)