### PR TITLE
Temporary fix for retries logic

### DIFF
--- a/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
+++ b/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
@@ -77,13 +77,9 @@ package object geotrellissentinelhub {
           case r: RetryException => s"${r.response.code}: ${r.response.header("Status").getOrElse("UNKNOWN")}"
           case _ => e.getMessage
         }
-        val retryAfter = e match {
-          case r: RetryException => r.response.header("Retry-After").getOrElse("10").toInt
-          case _ => 10
-        }
         logger.info(s"Attempt $i failed: $message -> $exMessage")
         if (i < nb) {
-          val exponentialRetryAfter = retryAfter * pow(2, i - 1).toInt
+          val exponentialRetryAfter = 1000 * pow(2, i - 1).toInt
           Thread.sleep(exponentialRetryAfter)
           logger.info(s"Retry $i after ${exponentialRetryAfter}ms: $message")
           retry(nb, message, i + 1)(fn)

--- a/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
+++ b/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
@@ -2,6 +2,7 @@ package org.openeo
 
 import java.io.InputStream
 import java.lang.Math.pow
+import java.lang.Math.random
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 import java.util.Scanner
@@ -79,9 +80,10 @@ package object geotrellissentinelhub {
         }
         logger.info(s"Attempt $i failed: $message -> $exMessage")
         if (i < nb) {
-          val exponentialRetryAfter = 1000 * pow(2, i - 1).toInt
-          Thread.sleep(exponentialRetryAfter)
-          logger.info(s"Retry $i after ${exponentialRetryAfter}ms: $message")
+          val exponentialRetryAfter = 1000 * pow(2, i - 1)
+          val retryAfterWithJitter = (exponentialRetryAfter * (0.5 + random)).toInt
+          Thread.sleep(retryAfterWithJitter)
+          logger.info(s"Retry $i after ${retryAfterWithJitter}ms: $message")
           retry(nb, message, i + 1)(fn)
         } else throw e
     }


### PR DESCRIPTION
The Sentinel Hub rate limiting provides `Retry-After` response header which advises clients on how long they should wait for before issuing a next request, to avoid being rate-limited. However, the assumption here is that there is only a _single_ consumer. When there are multiple consumers (as in this case) only one of them will be able to get the response while others will be (again) rejected.

Additionally, the code should react differently depending on the response status code:
- `429`: retry later
- other `4xx`: abort, there is some problem with the request
- `5xx`: retry later; backoff times should be larger to avoid compounding to service troubles

This PR is _not_ yet a proper solution - we should discuss the architecture of the system to find a better one. However, it should increase likelihood that each worker will be able to finish their work, because as soon as errors start, some workers will back off for non-trivial amount of time, leaving others enough space to continue, and hopefully not timing out themselves yet. 

Please see this PR as a suggestion for a temporary fix (feel free to disregard and close too). We can discuss better alternatives live.