### PR TITLE
Replace WCS with Process API (Sentinel Hub)

### DIFF
--- a/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
+++ b/geotrellis-sentinelhub/src/main/scala/org/openeo/geotrellissentinelhub/package.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 
 import geotrellis.raster.io.geotiff.SinglebandGeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
-import geotrellis.raster.{ArrayTile, FloatUserDefinedNoDataCellType, MultibandTile, Tile}
+import geotrellis.raster.{ArrayTile, MultibandTile, Tile, UShortConstantNoDataCellType}
 import geotrellis.vector.Extent
 import org.apache.commons.io.IOUtils
 import org.openeo.geotrellissentinelhub.bands.Band
@@ -71,13 +71,13 @@ package object geotrellissentinelhub {
           input: ["${band}"],
           output: {
             bands: ${nBands},
-            sampleType: "FLOAT32",
+            sampleType: "UINT16",
           }
         };
       }
 
       function evaluatePixel(sample) {
-        return [sample.${band}];
+        return [sample.${band} * 65535];
       }
     """
     val jsonFactory = new JsonFactory();
@@ -143,12 +143,12 @@ package object geotrellissentinelhub {
 
         val tiff = response.body.asInstanceOf[SinglebandGeoTiff]
 
-        tiff.tile.toArrayTile().withNoData(Some(1.0))
+        tiff.tile.withNoData(Some(UShortConstantNoDataCellType.noDataValue))
       }
     } catch {
       case e: Exception =>
         logger.warn(s"Returning empty tile: $e")
-        ArrayTile.empty(FloatUserDefinedNoDataCellType(1), width, height)
+        ArrayTile.empty(UShortConstantNoDataCellType, width, height)
     }
   }
 

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/PyramidFactoryTest.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/PyramidFactoryTest.scala
@@ -24,28 +24,28 @@ class PyramidFactoryTest {
   @Test
   def testGamma0(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 10, 10), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S1PyramidFactory(System.getProperty("uuid-gamma0")), "gamma0", date, Seq(IW_VV, IW_VH))
+    testLayer(new S1PyramidFactory(), "gamma0", date, Seq(IW_VV, IW_VH))
   }
 
   @Ignore
   @Test
   def testSentinel2L1C(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 21), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S2L1CPyramidFactory(System.getProperty("uuid-sentinel2-L1C")), "sentinel2-L1C", date, Seq(Sentinel2L1CBands.B04, Sentinel2L1CBands.B03, Sentinel2L1CBands.B02))
+    testLayer(new S2L1CPyramidFactory(), "sentinel2-L1C", date, Seq(Sentinel2L1CBands.B04, Sentinel2L1CBands.B03, Sentinel2L1CBands.B02))
   }
 
   @Ignore
   @Test
   def testSentinel2L2A(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 21), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S2L2APyramidFactory(System.getProperty("uuid-sentinel2-L2A")), "sentinel2-L2A", date, Seq(Sentinel2L2ABands.B08, Sentinel2L2ABands.B04, Sentinel2L2ABands.B03))
+    testLayer(new S2L2APyramidFactory(), "sentinel2-L2A", date, Seq(Sentinel2L2ABands.B08, Sentinel2L2ABands.B04, Sentinel2L2ABands.B03))
   }
 
   @Ignore
   @Test
   def testLandsat8(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 22), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new L8PyramidFactory(System.getProperty("uuid-landsat8")), "landsat8", date, Seq(B10, B11))
+    testLayer(new L8PyramidFactory(), "landsat8", date, Seq(B10, B11))
   }
   
   def testLayer[B <: Band](pyramidFactory: PyramidFactory[B], layer: String, date: ZonedDateTime, bands: Seq[B]): Unit = {

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/PyramidFactoryTest.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/PyramidFactoryTest.scala
@@ -20,32 +20,35 @@ import scala.collection.JavaConverters._
 
 class PyramidFactoryTest {
 
+  private val clientId = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_ID")
+  private val clientSecret = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_SECRET")
+
   @Ignore
   @Test
   def testGamma0(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 10, 10), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S1PyramidFactory(), "gamma0", date, Seq(IW_VV, IW_VH))
+    testLayer(new S1PyramidFactory(clientId, clientSecret), "gamma0", date, Seq(IW_VV, IW_VH))
   }
 
   @Ignore
   @Test
   def testSentinel2L1C(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 21), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S2L1CPyramidFactory(), "sentinel2-L1C", date, Seq(Sentinel2L1CBands.B04, Sentinel2L1CBands.B03, Sentinel2L1CBands.B02))
+    testLayer(new S2L1CPyramidFactory(clientId, clientSecret), "sentinel2-L1C", date, Seq(Sentinel2L1CBands.B04, Sentinel2L1CBands.B03, Sentinel2L1CBands.B02))
   }
 
   @Ignore
   @Test
   def testSentinel2L2A(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 21), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new S2L2APyramidFactory(), "sentinel2-L2A", date, Seq(Sentinel2L2ABands.B08, Sentinel2L2ABands.B04, Sentinel2L2ABands.B03))
+    testLayer(new S2L2APyramidFactory(clientId, clientSecret), "sentinel2-L2A", date, Seq(Sentinel2L2ABands.B08, Sentinel2L2ABands.B04, Sentinel2L2ABands.B03))
   }
 
   @Ignore
   @Test
   def testLandsat8(): Unit = {
     val date = ZonedDateTime.of(LocalDate.of(2019, 9, 22), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-    testLayer(new L8PyramidFactory(), "landsat8", date, Seq(B10, B11))
+    testLayer(new L8PyramidFactory(clientId, clientSecret), "landsat8", date, Seq(B10, B11))
   }
   
   def testLayer[B <: Band](pyramidFactory: PyramidFactory[B], layer: String, date: ZonedDateTime, bands: Seq[B]): Unit = {

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestS1Gamma0.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestS1Gamma0.scala
@@ -14,11 +14,9 @@ class TestS1Gamma0 {
     val bbox = new Extent(-5948635.289265557,-1252344.2714243263,-5792092.255337516,-1095801.2374962857)
 
     val date = LocalDate.of(2019, 6, 1).atStartOfDay(ZoneId.systemDefault())
-    
-    val uuid = System.getProperty("uuid")
-    val endpoint = "https://services.sentinel-hub.com"
-    
-    retrieveTileFromSentinelHub(uuid, endpoint, bbox, date, 256, 256, allBands)
+
+    val datasetId = "S1GRD"
+    retrieveTileFromSentinelHub(datasetId, bbox, date, 256, 256, allBands)
   }
 
 }

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestS1Gamma0.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestS1Gamma0.scala
@@ -7,7 +7,10 @@ import org.junit.{Ignore, Test}
 import org.openeo.geotrellissentinelhub.bands.Sentinel1Bands._
 
 class TestS1Gamma0 {
-  
+
+  private val clientId = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_ID")
+  private val clientSecret = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_SECRET")
+
   @Test
   @Ignore
   def testGamma0(): Unit = {
@@ -16,7 +19,7 @@ class TestS1Gamma0 {
     val date = LocalDate.of(2019, 6, 1).atStartOfDay(ZoneId.systemDefault())
 
     val datasetId = "S1GRD"
-    retrieveTileFromSentinelHub(datasetId, bbox, date, 256, 256, allBands)
+    retrieveTileFromSentinelHub(datasetId, bbox, date, 256, 256, allBands, clientId, clientSecret)
   }
 
 }

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestSameStartEndDate.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestSameStartEndDate.scala
@@ -28,10 +28,8 @@ class TestSameStartEndDate {
         .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
         .set("spark.kryoserializer.buffer.max", "1024m"))
 
-    val uuid = System.getProperty("uuid-gamma0")
-    
-    val pyramid = new S1PyramidFactory(uuid).pyramid_seq(extent, bbox_srs, from, to, bands)
-    
+    val pyramid = new S1PyramidFactory().pyramid_seq(extent, bbox_srs, from, to, bands)
+
     val topLevelRdd = pyramid.filter(r => r._1 == 14).head._2
     
     val results = topLevelRdd.collect()

--- a/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestSameStartEndDate.scala
+++ b/geotrellis-sentinelhub/src/test/scala/org/openeo/geotrellissentinelhub/TestSameStartEndDate.scala
@@ -8,6 +8,9 @@ import org.junit.{Ignore, Test}
 
 class TestSameStartEndDate {
 
+  private val clientId = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_ID")
+  private val clientSecret = Utils.getRequiredSystemProperty("SENTINELHUB_CLIENT_SECRET")
+
   @Test
   @Ignore
   def testSameStartEndDate(): Unit = {
@@ -28,7 +31,7 @@ class TestSameStartEndDate {
         .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
         .set("spark.kryoserializer.buffer.max", "1024m"))
 
-    val pyramid = new S1PyramidFactory().pyramid_seq(extent, bbox_srs, from, to, bands)
+    val pyramid = new S1PyramidFactory(clientId, clientSecret).pyramid_seq(extent, bbox_srs, from, to, bands)
 
     val topLevelRdd = pyramid.filter(r => r._1 == 14).head._2
     


### PR DESCRIPTION
This PR replaces WCS requests with [Sentinel Hub Process API](https://docs.sentinel-hub.com/api/latest/api/process/) ([API reference](https://docs.sentinel-hub.com/api/latest/reference/#tag/process)). This API is much more powerful and even allows things such as data fusion between datasets.

There are a couple of things that this PR _doesn't_ solve:

- `authToken` (see [Sentinel Hub authentication](https://docs.sentinel-hub.com/api/latest/api/overview/authentication/)) must be somehow obtained from the service and distributed to workers. Instead of assuming, I have simply created an `authToken` variable, but this was of course only useful for very basic testing.

- Sentinel Hub API (both OGC WMS/WCS and Process API) allows fetching multiple bands in a single request, which is much more efficient. As this is out of scope for fetching data (it needs to be consumed properly too) I have simply indicated where the bands should be specified if you wish to fetch multiple at once (see use of `band` and `nBands` variables withing the `evalscript` definition).

- the original code fetched TIFF 32f, which is not very efficient, especially as the original data doesn't have such resolution either. I would suggest changing this to TIFF 16. **IMPORTANT:** if you do this, make sure to also change the `evalscript` so that it returns data between min / max possible value, otherwise the images will only have values `0` and `1`.

- I was able to run this code by commenting out `@Ignore` on one of the tests (`testSentinel2L2A`); however, while it seemed to work, there could be some bugs. The test also didn't fail when the requests failed so I am not sure it is finished. Please test additionally.

