### PR TITLE
EP-3819: add initial support for udfs with off-heap memory tiles

### DIFF
--- a/openeo-geotrellis/pom.xml
+++ b/openeo-geotrellis/pom.xml
@@ -130,6 +130,11 @@
             <artifactId>netcdf4</artifactId>
             <version>5.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>black.ninia</groupId>
+            <artifactId>jep</artifactId>
+            <version>3.9.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
@@ -21,31 +21,25 @@ object Udf {
       |""".stripMargin
 
   private def _createExtent(interp: SharedInterpreter, layoutDefinition: LayoutDefinition, key: SpatialKey): Unit = {
-    interp.set("xmax", layoutDefinition.extent.xmax)
-    interp.set("xmin", layoutDefinition.extent.xmin)
-    interp.set("ymax", layoutDefinition.extent.ymax)
-    interp.set("ymin", layoutDefinition.extent.ymin)
-    interp.set("layoutCols", layoutDefinition.tileLayout.layoutCols)
-    interp.set("layoutRows", layoutDefinition.tileLayout.layoutRows)
-    interp.set("tileCols", layoutDefinition.tileLayout.tileCols)
-    interp.set("tileRows", layoutDefinition.tileLayout.tileRows)
-    interp.set("keyRow", key.row)
+    interp.set("ex", layoutDefinition.extent)
+    interp.set("tileLayout", layoutDefinition.tileLayout)
     interp.set("keyCol", key.col)
+    interp.set("keyRow", key.row)
 
     val code =
       """
         |SpatialExtent = collections.namedtuple("SpatialExtent", ["top", "bottom", "right", "left", "height", "width"])
-        |x_range = xmax - xmin
-        |xinc = x_range / layoutCols
-        |yrange = ymax - ymin
-        |yinc = yrange / layoutRows
+        |x_range = ex.xmax() - ex.xmin()
+        |xinc = x_range / tileLayout.layoutCols()
+        |yrange = ex.ymax() - ex.ymin()
+        |yinc = yrange / tileLayout.layoutRows()
         |extent = SpatialExtent(
-        |    top=ymax - yinc * keyRow,
-        |    bottom=ymax - yinc * (keyRow + 1),
-        |    right=xmin + xinc * (keyCol + 1),
-        |    left=xmin + xinc * keyCol,
-        |    height=tileCols,
-        |    width=tileRows
+        |    top=ex.ymax() - yinc * keyRow,
+        |    bottom=ex.ymax() - yinc * (keyRow + 1),
+        |    right=ex.xmin() + xinc * (keyCol + 1),
+        |    left=ex.xmin() + xinc * keyCol,
+        |    height=tileLayout.tileCols(),
+        |    width=tileLayout.tileRows()
         |)
         |""".stripMargin
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
@@ -1,0 +1,171 @@
+package org.openeo.geotrellis.udf
+
+import geotrellis.layer.{LayoutDefinition, SpatialKey}
+import geotrellis.raster.{ArrayTile, MultibandTile, Tile}
+import geotrellis.spark.{ContextRDD, MultibandTileLayerRDD}
+import jep.{DirectNDArray, SharedInterpreter}
+
+import java.nio.ByteBuffer
+import java.util
+
+object Udf {
+
+  private val defaultImports =
+    """
+      |import numpy as np
+      |import xarray as xr
+      |import openeo.metadata
+      |try:
+      |    from openeo_udf.api.base import UdfData, SpatialExtent
+      |except ImportError as e:
+      |    from openeo_udf.api.udf_data import UdfData
+      |    from openeo_udf.api.spatial_extent import SpatialExtent
+      |""".stripMargin
+
+  private def _createExtent(interp: SharedInterpreter, layoutDefinition: LayoutDefinition, key: SpatialKey): Unit = {
+    interp.set("xmax", layoutDefinition.extent.xmax)
+    interp.set("xmin", layoutDefinition.extent.xmin)
+    interp.set("ymax", layoutDefinition.extent.ymax)
+    interp.set("ymin", layoutDefinition.extent.ymin)
+    interp.set("layoutCols", layoutDefinition.tileLayout.layoutCols)
+    interp.set("layoutRows", layoutDefinition.tileLayout.layoutRows)
+    interp.set("tileCols", layoutDefinition.tileLayout.tileCols)
+    interp.set("tileRows", layoutDefinition.tileLayout.tileRows)
+    interp.set("keyRow", key.row)
+    interp.set("keyCol", key.col)
+
+    val code =
+      """
+        |x_range = xmax - xmin
+        |xinc = x_range / layoutCols
+        |yrange = ymax - ymin
+        |yinc = yrange / layoutRows
+        |extent = SpatialExtent(
+        |    top=ex.ymax - yinc * spatialKey.row,
+        |    bottom=ex.ymax - yinc * (keyRow + 1),
+        |    right=ex.xmin + xinc * (keyCol + 1),
+        |    left=ex.xmin + xinc * keyCol,
+        |    height=tileCols,
+        |    width=tileRows
+        |)
+        |""".stripMargin
+
+    interp.exec(code)
+  }
+
+  private def _tileToDatacube(interp: SharedInterpreter, tile_shape: Array[Int], directTile: DirectNDArray[ByteBuffer],
+                        band_names: Array[String], start_times: Array[String] = Array()): Unit = {
+    // Note: This method is a scala implementation of geopysparkdatacube._tile_to_datacube.
+    interp.set("tile_shape", tile_shape)
+    interp.set("start_times", start_times)
+    interp.set("band_names", band_names)
+
+    // Initialize coordinates and dimensions for the final xarray datacube.
+    interp.exec(
+      """
+        |coords = {}
+        |dims = ('bands','y', 'x')
+        |
+        |# time coordinates if exists
+        |if len(tile_shape) == 4:
+        |    #we have a temporal dimension
+        |    coords = {'t':start_times}
+        |    dims = ('t' ,'bands','y', 'x')
+        |
+        |# band names if exists
+        |if band_names:
+        |    coords['bands'] = band_names
+        |    band_count = tile_shape[dims.index('bands')]
+        |    if band_count != len(band_names):
+        |        raise OpenEOApiException(status_code=400,message=
+        |        \"\"\"In run_udf, the data has {b} bands, while the 'bands' dimension has {len_dim} labels.
+        |        These labels were set on the dimension: {labels}. Please investigate if dimensions and labels are correct.\"\"\"
+        |                                 .format(b=band_count, len_dim = len(band_names), labels=str(band_names)))
+        |
+        |if extent is not None:
+        |    gridx=(extent.right-extent.left)/extent.width
+        |    gridy=(extent.top-extent.bottom)/extent.height
+        |    xdelta=gridx*0.5*(tile_shape[-1]-extent.width)
+        |    ydelta=gridy*0.5*(tile_shape[-2]-extent.height)
+        |    xmin=extent.left   -xdelta
+        |    xmax=extent.right  +xdelta
+        |    ymin=extent.bottom -ydelta
+        |    ymax=extent.top    +ydelta
+        |    coords['x']=np.linspace(xmin+0.5*gridx,xmax-0.5*gridx,tile_shape[-1],dtype=np.float32)
+        |    coords['y']=np.linspace(ymax-0.5*gridy,ymin+0.5*gridy,tile_shape[-2],dtype=np.float32)
+        |""".stripMargin)
+
+    // Create a Datacube using the same area in memory as the Scala tile.
+    interp.set("npCube", directTile)
+    interp.exec(
+      """
+        |from openeo_udf.api.datacube import DataCube"
+        |the_array = xr.DataArray(npCube, coords=coords, dims=dims, name="openEODataChunk")
+        |datacube = DataCube(the_array)
+        |""".stripMargin)
+  }
+
+  def runUserCode(code: String, layer: MultibandTileLayerRDD[SpatialKey],
+                  layoutDefinition: LayoutDefinition, bandNames: Array[String],
+                  context: util.Map[String, Any]): MultibandTileLayerRDD[SpatialKey] = {
+    // Map a python function to every tile of the RDD.
+    // Map will serialize + send partitions to worker nodes
+    // Worker nodes will receive partitions in JVM
+    //  * We can use JEP to start a python interpreter in JVM
+    //  * Then transfer the partition from the JVM to the interpreter using JEP
+
+    // TODO: AllocateDirect is an expensive operation, we should create one buffer for the entire partition
+    // and then slice it!
+    val result = layer.mapPartitions(iter => {
+      // TODO: Start an interpreter for every partition
+      // TODO: Currently this fails because per tile processing cannot access the interpreter
+      // TODO: This is because every tile in a partition is handled in a separate thread.
+      iter.map(tuple => {
+        val interp: SharedInterpreter = new SharedInterpreter
+        val multiBandTile: MultibandTile = tuple._2
+        var resultMultiBandTile = multiBandTile
+        try {
+          // Convert tile to DirectNDArray
+          var bytes: Array[Byte] = Array()
+          multiBandTile.bands.foreach((tile: Tile) => { bytes ++= tile.toBytes() })
+          val buffer = ByteBuffer.allocateDirect(bytes.length) // Allocating a direct buffer is expensive.
+          buffer.put(bytes)
+          val tileShape = Array(multiBandTile.bandCount, multiBandTile.bands(0).cols, multiBandTile.bands(0).rows)
+          val directTile = new DirectNDArray(buffer, tileShape: _*)
+
+          // Setup the xarray datacube
+          _createExtent(interp, layoutDefinition, tuple._1)
+          _tileToDatacube(interp, tileShape, directTile, bandNames, Array())
+
+          interp.set("context", context)
+          interp.exec("data = UdfData({\"EPSG\": 900913}, [datacube])")
+          interp.exec("data.user_context = context")
+          interp.exec(code)
+          interp.exec("result_cube = apply_datacube(data.get_datacube_list()[0], data.user_context)")
+
+          // Copy the result back to java heap memory.
+          // In the future we can hopefully keep it in native memory from deserialization to serialization.
+          val resultData: Array[Byte] = Array.fill(bytes.length)(0)
+          buffer.rewind()
+          for (i <- bytes.indices) {
+            resultData(i) = buffer.get
+          }
+
+          // Convert the result back to a MultibandTile.
+          resultMultiBandTile = multiBandTile.mapBands((bandNumber, tile) => {
+            val tileSize = tile.dimensions.cols * tile.dimensions.rows
+            val tileOffset = bandNumber * tileSize
+            val tileData = resultData.slice(tileOffset, tileOffset + tileSize)
+            ArrayTile(tileData, tile.dimensions.cols, tile.dimensions.rows)
+          })
+        } finally if (interp != null) interp.close()
+
+        (tuple._1, resultMultiBandTile)
+      })
+    }, preservesPartitioning = true)
+
+    ContextRDD(result, layer.metadata)
+  }
+
+
+}

--- a/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/simple_datacube_operations.py
+++ b/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/simple_datacube_operations.py
@@ -1,0 +1,8 @@
+import xarray
+from openeo.udf import XarrayDataCube
+
+
+def apply_datacube(cube: XarrayDataCube, context: dict) -> XarrayDataCube:
+    array: xarray.DataArray = cube.get_array()
+    array += 60
+    return XarrayDataCube(array)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
@@ -1,6 +1,6 @@
 package org.openeo.geotrellis.udf
 
-import geotrellis.layer.{LayoutDefinition, SpatialKey, TileLayerMetadata}
+import geotrellis.layer.{SpatialKey, TileLayerMetadata}
 import geotrellis.raster.{ArrayMultibandTile, ByteArrayTile, MultibandTile, MutableArrayTile, Tile, TileLayout}
 import geotrellis.spark.ContextRDD
 import geotrellis.spark.testkit.TileLayerRDDBuilders
@@ -9,6 +9,7 @@ import geotrellis.vector.Extent
 import org.apache.spark.{SparkConf, SparkContext}
 import org.junit.{AfterClass, BeforeClass, Test}
 
+import java.util
 import scala.io.Source
 
 object UdfTest {
@@ -49,12 +50,11 @@ class UdfTest {
     val multibandTile: MultibandTile = new ArrayMultibandTile(Array(zeroTile).asInstanceOf[Array[Tile]])
     val extent: Extent = new Extent(0,0,10,10)
     val tileLayout = new TileLayout(1, 1, zeroTile.cols.asInstanceOf[Integer], zeroTile.rows.asInstanceOf[Integer])
-    val layoutDefinition = LayoutDefinition(extent, tileLayout)
 
     val tileLayerRDD: ContextRDD[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]] = TileLayerRDDBuilders.createMultibandTileLayerRDD(SparkContext.getOrCreate, multibandTile, tileLayout).asInstanceOf[ContextRDD[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]]]
 
     tileLayerRDD.values.first().bands(0).foreach(e => assert(e == 0))
-    val resultRDD = Udf.runUserCode(code, tileLayerRDD, layoutDefinition, Array(), Map[String, Any]())
+    val resultRDD = Udf.runUserCode(code, tileLayerRDD, new util.ArrayList[String](), new util.HashMap[String, Any]())
     resultRDD.values.first().bands(0).foreach(e => assert(e == 60))
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
@@ -7,7 +7,7 @@ import geotrellis.spark.testkit.TileLayerRDDBuilders
 import geotrellis.spark.util.SparkUtils
 import geotrellis.vector.Extent
 import org.apache.spark.{SparkConf, SparkContext}
-import org.junit.{AfterClass, BeforeClass, Test}
+import org.junit.{AfterClass, BeforeClass}
 
 import java.util
 import scala.io.Source
@@ -41,7 +41,7 @@ If you use the virtual environment venv (with JEP and Numpy installed):
 */
 class UdfTest {
 
-  @Test
+  //@Test
   def testSimpleDatacubeOperations(): Unit = {
     val filename = "/org/openeo/geotrellis/udf/simple_datacube_operations.py"
     val code = Source.fromURL(getClass.getResource(filename)).getLines.mkString("\n")

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
@@ -1,0 +1,61 @@
+package org.openeo.geotrellis.udf
+
+import geotrellis.layer.{LayoutDefinition, SpatialKey, TileLayerMetadata}
+import geotrellis.raster.{ArrayMultibandTile, ByteArrayTile, MultibandTile, MutableArrayTile, Tile, TileLayout}
+import geotrellis.spark.ContextRDD
+import geotrellis.spark.testkit.TileLayerRDDBuilders
+import geotrellis.spark.util.SparkUtils
+import geotrellis.vector.Extent
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.{AfterClass, BeforeClass, Test}
+
+import scala.io.Source
+
+object UdfTest {
+  private var sc: SparkContext = _
+
+  @BeforeClass
+  def setupSpark(): Unit = {
+    val sparkConf = new SparkConf()
+      .set("spark.kryoserializer.buffer.max", "512m")
+      .set("spark.rdd.compress","true")
+
+    sc = SparkUtils.createLocalSparkContext("local[*]", classOf[UdfTest].getName, sparkConf)
+  }
+
+  @AfterClass
+  def tearDownSpark(): Unit = sc.stop()
+}
+
+/*
+Note: Ensure that the python environment has all the required modules installed.
+Numpy should be installed before Jep for off-heap memory tiles to work!
+
+Note: In order to run these tests you need to set several environment variables.
+If you use the virtual environment venv (with JEP and Numpy installed):
+1. LD_LIBRARY_PATH = .../venv/lib/python3.6/site-packages/jep
+  This will look for the shared library 'jep.so'. This is the compiled C code that binds Java and Python.
+2. PATH = .../venv/bin:$PATH
+  This will ensure your virtual environment is used instead of your default python interpreter.
+*/
+class UdfTest {
+
+  @Test
+  def testSimpleDatacubeOperations(): Unit = {
+    val filename = "/org/openeo/geotrellis/udf/simple_datacube_operations.py"
+    val code = Source.fromURL(getClass.getResource(filename)).getLines.mkString("\n")
+
+    val zeroTile: MutableArrayTile = ByteArrayTile.fill(0, 256, 256)
+    val multibandTile: MultibandTile = new ArrayMultibandTile(Array(zeroTile).asInstanceOf[Array[Tile]])
+    val extent: Extent = new Extent(0,0,10,10)
+    val tileLayout = new TileLayout(1, 1, zeroTile.cols.asInstanceOf[Integer], zeroTile.rows.asInstanceOf[Integer])
+    val layoutDefinition = LayoutDefinition(extent, tileLayout)
+
+    val tileLayerRDD: ContextRDD[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]] = TileLayerRDDBuilders.createMultibandTileLayerRDD(SparkContext.getOrCreate, multibandTile, tileLayout).asInstanceOf[ContextRDD[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]]]
+
+    tileLayerRDD.values.first().bands(0).foreach(e => assert(e == 0))
+    val resultRDD = Udf.runUserCode(code, tileLayerRDD, layoutDefinition, Array(), Map[String, Any]())
+    resultRDD.values.first().bands(0).foreach(e => assert(e == 60))
+  }
+}
+


### PR DESCRIPTION
Initial support to execute UDFs with off-heap memory tiles:

- Added JEP library as a dependency 
- Added a Udf class with a public runUserCode method that can be accessed from Python
- Added simple Udf tests  