### PR TITLE
#80 fix loading small portion of global file

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/file/AgEra5PyramidFactory2.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/file/AgEra5PyramidFactory2.scala
@@ -6,7 +6,7 @@ import org.openeo.opensearch.backends.Agera5SearchClient
 
 import java.util
 
-class AgEra5PyramidFactory2(dataGlob: String, bandFileMarkers: util.List[String], dateRegex: String, maxSpatialResolution: CellSize) extends Sentinel2PyramidFactory("http://dummy.endpoint.com","", bandFileMarkers, "", maxSpatialResolution: CellSize,experimental = true) {
+class AgEra5PyramidFactory2(dataGlob: String, bandFileMarkers: util.List[String], dateRegex: String, maxSpatialResolution: CellSize) extends Sentinel2PyramidFactory("http://dummy.endpoint.com","", bandFileMarkers, "", maxSpatialResolution: CellSize,experimental = false) {
   override def createOpenSearch: OpenSearchClient = {
     new Agera5SearchClient(dataGlob, bandFileMarkers, dateRegex.r.unanchored)
   }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -11,7 +11,7 @@ import geotrellis.raster.gdal.{GDALPath, GDALRasterSource, GDALWarpOptions}
 import geotrellis.raster.geotiff.{GeoTiffPath, GeoTiffReprojectRasterSource, GeoTiffResampleRasterSource}
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.rasterize.Rasterizer
-import geotrellis.raster.{CellSize, CellType, ConvertTargetCellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetCellType, TargetRegion, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
+import geotrellis.raster.{CellSize, CellType, ConvertTargetCellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetAlignment, TargetCellType, TargetRegion, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
 import geotrellis.spark._
 import geotrellis.spark.partition.SpacePartitioner
 import geotrellis.vector._
@@ -621,7 +621,8 @@ class FileLayerProvider(openSearch: OpenSearchClient, openSearchCollectionId: St
           if(experimental) {
             Seq(GDALRasterSource(dataPath, options = GDALWarpOptions(alignTargetPixels = true, cellSize = Some(maxSpatialResolution)), targetCellType = targetCellType))
           }else{
-            Seq(GeoTiffResampleRasterSource(GeoTiffPath(dataPath), alignment, NearestNeighbor, OverviewStrategy.DEFAULT, targetCellType, None))
+            //here we can use 'TargetAlignment' because there is no reprojection of the extent. It would be better if we could also use 'TargetRegion', but that breaks the handling of overlap
+            Seq(GeoTiffResampleRasterSource(GeoTiffPath(dataPath), TargetAlignment(re), NearestNeighbor, OverviewStrategy.DEFAULT, targetCellType, None))
           }
         }else{
           if(experimental) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -11,7 +11,7 @@ import geotrellis.raster.gdal.{GDALPath, GDALRasterSource, GDALWarpOptions}
 import geotrellis.raster.geotiff.{GeoTiffPath, GeoTiffReprojectRasterSource, GeoTiffResampleRasterSource}
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.rasterize.Rasterizer
-import geotrellis.raster.{CellSize, CellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, InterpretAsTargetCellType, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetCellType, TargetRegion, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
+import geotrellis.raster.{CellSize, CellType, ConvertTargetCellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetCellType, TargetRegion, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
 import geotrellis.spark._
 import geotrellis.spark.partition.SpacePartitioner
 import geotrellis.vector._

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -11,7 +11,7 @@ import geotrellis.raster.gdal.{GDALPath, GDALRasterSource, GDALWarpOptions}
 import geotrellis.raster.geotiff.{GeoTiffPath, GeoTiffReprojectRasterSource, GeoTiffResampleRasterSource}
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.rasterize.Rasterizer
-import geotrellis.raster.{CellSize, CellType, ConvertTargetCellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetAlignment, TargetCellType, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
+import geotrellis.raster.{CellSize, CellType, FloatConstantNoDataCellType, FloatConstantTile, GridBounds, GridExtent, InterpretAsTargetCellType, MosaicRasterSource, MultibandTile, NoNoData, PaddedTile, Raster, RasterExtent, RasterMetadata, RasterRegion, RasterSource, ResampleMethod, ResampleTarget, SourceName, SourcePath, TargetCellType, TargetRegion, UByteUserDefinedNoDataCellType, UShortConstantNoDataCellType}
 import geotrellis.spark._
 import geotrellis.spark.partition.SpacePartitioner
 import geotrellis.vector._
@@ -144,7 +144,6 @@ object FileLayerProvider {
   private val logger = LoggerFactory.getLogger(classOf[FileLayerProvider])
 
   {
-    logger.info("Setting GdalWarp cache size to 32.")
     GDALWarp.init(32)
   }
 
@@ -594,10 +593,10 @@ class FileLayerProvider(openSearch: OpenSearchClient, openSearchCollectionId: St
 
   private def deriveRasterSources(feature: Feature, targetExtent:ProjectedExtent): List[(RasterSource, Seq[Int])] = {
     def expandToCellSize(extent: Extent, cellSize: CellSize): Extent =
-      extent.expandBy(deltaX = (cellSize.width - extent.width) / 2, deltaY = (cellSize.height - extent.height) / 2)
+      extent.expandBy(deltaX = math.max((cellSize.width - extent.width) / 2,0.0), deltaY = math.max((cellSize.height - extent.height) / 2,0.0))
 
-    val re = RasterExtent(expandToCellSize(targetExtent.extent, maxSpatialResolution), maxSpatialResolution).alignTargetPixels
-    val alignment = TargetAlignment(re)
+    val re = RasterExtent(expandToCellSize(targetExtent.extent,maxSpatialResolution), maxSpatialResolution).alignTargetPixels
+    val alignment = TargetRegion(re)
 
     def vsisToHttpsCreo(path: String): String = {
       path.replace("/vsicurl/", "").replace("/vsis3/eodata", "https://finder.creodias.eu/files")

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/TestImplicits.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/TestImplicits.scala
@@ -1,13 +1,13 @@
 package org.openeo.geotrellis
 
-import java.util.zip.Deflater.BEST_COMPRESSION
-
 import geotrellis.layer.SpatialKey
 import geotrellis.raster.Raster
 import geotrellis.raster.io.geotiff.compression.DeflateCompression
-import geotrellis.raster.io.geotiff.{GeoTiffOptions, MultibandGeoTiff, SinglebandGeoTiff, Tags}
+import geotrellis.raster.io.geotiff.{GeoTiffOptions, SinglebandGeoTiff, Tags}
 import geotrellis.spark._
 import geotrellis.vector.ProjectedExtent
+
+import java.util.zip.Deflater.BEST_COMPRESSION
 
 object TestImplicits {
   implicit class TileGeoTiffOutputMethods(spatialLayer: TileLayerRDD[SpatialKey]) {
@@ -24,16 +24,9 @@ object TestImplicits {
 
   implicit class MultibandTileGeoTiffOutputMethods(spatialLayer: MultibandTileLayerRDD[SpatialKey]) {
     def writeGeoTiff(path: String, bbox: ProjectedExtent = null): Unit = {
-      val Raster(tile, extent) = {
-        val stitched = spatialLayer.stitch()
-        if (bbox != null) stitched.crop(bbox.reproject(spatialLayer.metadata.crs))
-        else stitched
-      }
+      val maybeBBox = Option(bbox).map(_.reproject(spatialLayer.metadata.crs))
+      org.openeo.geotrellis.geotiff.saveRDD(spatialLayer,-1,path,6,maybeBBox)
 
-      val options = GeoTiffOptions(DeflateCompression(BEST_COMPRESSION))
-
-      MultibandGeoTiff(tile, extent, spatialLayer.metadata.crs, Tags.empty, options)
-        .write(path)
     }
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
@@ -2,17 +2,17 @@ package org.openeo.geotrellis.layers
 
 import cats.data.NonEmptyList
 import geotrellis.layer.FloatingLayoutScheme
-
-import java.time.{LocalDate, ZoneId}
-import geotrellis.proj4.LatLng
-import geotrellis.raster.CellSize
+import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.raster.{CellSize, FloatConstantNoDataCellType}
 import geotrellis.spark._
 import geotrellis.vector.{Extent, ProjectedExtent}
+import org.junit.Assert._
 import org.junit.Test
 import org.openeo.geotrellis.TestImplicits._
 import org.openeo.geotrellis.{LocalSparkContext, ProjectedPolygons}
 import org.openeo.opensearch.backends.Agera5SearchClient
 
+import java.time.{LocalDate, ZoneId}
 import java.util
 import scala.collection.JavaConverters.asScalaBuffer
 
@@ -22,40 +22,59 @@ class AgEra5FileLayerProviderTest {
   import AgEra5FileLayerProviderTest._
 
   private val bands: util.List[String] = util.Arrays.asList("dewpoint-temperature", "precipitation-flux", "solar-radiation-flux")
+
+  private def layerProvider = new FileLayerProvider(new Agera5SearchClient(dataGlob = "/data/MEP/ECMWF/AgERA5/2020/20200424/AgERA5_dewpoint-temperature_*.tif", bands, raw".+_(\d{4})(\d{2})(\d{2})\.tif".r),"",
+    NonEmptyList.fromList(asScalaBuffer(bands).toList).get,
+    rootPath = "/data/MEP/ECMWF/AgERA5",
+    maxSpatialResolution = CellSize(0.1, 0.1),
+    new Sentinel5PPathDateExtractor(maxDepth = 3),
+    layoutScheme = FloatingLayoutScheme(256), experimental = false)
+
   private def layerProvider2 = new FileLayerProvider(new Agera5SearchClient(dataGlob = "/data/MEP/ECMWF/AgERA5/2020/20200424/AgERA5_dewpoint-temperature_*.tif", bands, raw".+_(\d{4})(\d{2})(\d{2})\.tif".r),"",
     NonEmptyList.fromList(asScalaBuffer(bands).toList).get,
     rootPath = "/data/MEP/ECMWF/AgERA5",
-    maxSpatialResolution = CellSize(0.099999998304108, 0.100000000000000),
+    maxSpatialResolution = CellSize(3000, 3000),
     new Sentinel5PPathDateExtractor(maxDepth = 3),
-    layoutScheme = FloatingLayoutScheme(256))
+    layoutScheme = FloatingLayoutScheme(256), experimental = false)
+
+  private val extent: Extent = Extent(0.0, 50.0, 5.0, 55.0)
+
 
   @Test
   def agEra5FileLayerProvider(): Unit = {
-    val fileLayerProvider = new AgEra5FileLayerProvider(
-      dewPointTemperatureGlob = "/data/MEP/ECMWF/AgERA5/2020/20200424/AgERA5_dewpoint-temperature_*.tif",
-      bandFileMarkers = Seq("dewpoint-temperature", "precipitation-flux", "solar-radiation-flux"),
-      dateRegex = raw".+_(\d{4})(\d{2})(\d{2})\.tif".r
-    )
 
-    val projectedExtent = ProjectedExtent(Extent(0.0, 50.0, 5.0, 55.0), LatLng)
+    val projectedExtent = ProjectedExtent(extent, LatLng)
     val projectedPolygons = ProjectedPolygons.fromExtent(projectedExtent.extent, s"EPSG:${projectedExtent.crs.epsgCode.get}")
 
     val from = LocalDate.of(2020, 4, 24).atStartOfDay(ZoneId.of("UTC"))
     val to = from
 
-    val layer = fileLayerProvider.readMultibandTileLayer(from, to, projectedPolygons, fileLayerProvider.maxZoom, sc,None)
+    val layer = layerProvider.readMultibandTileLayer(from, to, projectedExtent, projectedPolygons.polygons, projectedPolygons.crs, layerProvider.maxZoom, sc, None)
 
     val spatialLayer = layer
       .toSpatial(from)
       .cache()
 
+    val histogram = spatialLayer.histogram()
+
+    assertEquals(27779.0,histogram(0).mean().get,1.0)
+    assertEquals(21.69,histogram(1).mean().get,0.01)
+    assertEquals(16672090,histogram(2).mean().get,1.0)
+    assertEquals(48336,histogram(0).totalCount())
+    assertEquals(45601,histogram(1).totalCount())
+    assertEquals(65536,histogram(2).totalCount())
+
+    assertEquals(FloatConstantNoDataCellType, spatialLayer.metadata.cellType)
+    assertEquals(LatLng, spatialLayer.metadata.crs)
+    assertEquals(extent, spatialLayer.metadata.extent)
     spatialLayer
       .writeGeoTiff(s"/tmp/agEra5FileLayerProvider.tif", projectedExtent)
   }
 
   @Test
   def agEra5WithOpensearchClient(): Unit = {
-    val projectedExtent = ProjectedExtent(Extent(0.0, 50.0, 5.0, 55.0), LatLng)
+    val utm31 = CRS.fromEpsgCode(32631)
+    val projectedExtent = ProjectedExtent(ProjectedExtent(extent, LatLng).reproject(utm31),utm31)
     val projectedPolygons = ProjectedPolygons.fromExtent(projectedExtent.extent, s"EPSG:${projectedExtent.crs.epsgCode.get}")
 
     val from = LocalDate.of(2020, 4, 24).atStartOfDay(ZoneId.of("UTC"))
@@ -67,8 +86,20 @@ class AgEra5FileLayerProviderTest {
       .toSpatial(from)
       .cache()
 
-    spatialLayer
-      .writeGeoTiff(s"/tmp/agEra5WithOpensearchClient.tif", projectedExtent)
+    val histogram = spatialLayer.histogram()
+
+    assertEquals(27899.0,histogram(0).mean().get,1.0)
+    assertEquals(0.24366,histogram(1).mean().get,0.00001)
+    assertEquals(11426619,histogram(2).mean().get,1.0)
+    assertEquals(10087,histogram(0).totalCount())
+    assertEquals(11278,histogram(1).totalCount())
+    assertEquals(21913,histogram(2).totalCount())
+
+    assertEquals(FloatConstantNoDataCellType, spatialLayer.metadata.cellType)
+    assertEquals(utm31, spatialLayer.metadata.crs)
+
+    spatialLayer.writeGeoTiff(s"/tmp/agEra5WithOpensearchClient2.tif", projectedExtent)
+    assertEquals(projectedExtent.extent, spatialLayer.metadata.extent)
   }
 
 }


### PR DESCRIPTION
…pose an extent that is valid in the CRS.

For instance, a file with a global extent (agera5) does not have a properly valid extent in UTM31.