### PR TITLE
ctx:logFile empty

### DIFF
--- a/openeo-logging/pom.xml
+++ b/openeo-logging/pom.xml
@@ -62,6 +62,12 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/openeo-logging/src/test/resources/log4j2-batch.xml
+++ b/openeo-logging/src/test/resources/log4j2-batch.xml
@@ -7,7 +7,7 @@
         <Routing name="route">
             <Routes pattern="$${ctx:logFile}">
                 <Route>
-                    <File name="file" fileName="${ctx:logFile}">
+                    <File name="file" fileName="${ctx:logFile:-/dev/null}">
                         <JsonTemplateLayout eventTemplateUri="classpath:OpenEOBatchJobJsonLogLayout.json"
                                             locationInfoEnabled="true"/>
                     </File>

--- a/openeo-logging/src/test/resources/log4j2-batch.xml
+++ b/openeo-logging/src/test/resources/log4j2-batch.xml
@@ -5,9 +5,9 @@
                                 locationInfoEnabled="true"/>
         </Console>
         <Routing name="route">
-            <Routes pattern="$${ctx:logFile}">
+            <Routes pattern="$${env:LOG_FILE}">
                 <Route>
-                    <File name="file" fileName="${ctx:logFile:-/dev/null}">
+                    <File name="file" fileName="${env:LOG_FILE}">
                         <JsonTemplateLayout eventTemplateUri="classpath:OpenEOBatchJobJsonLogLayout.json"
                                             locationInfoEnabled="true"/>
                     </File>

--- a/openeo-logging/src/test/resources/log4j2-sync.xml
+++ b/openeo-logging/src/test/resources/log4j2-sync.xml
@@ -7,7 +7,7 @@
         <Routing name="route">
             <Routes pattern="$${ctx:logFile}">
                 <Route>
-                    <File name="file" fileName="${ctx:logFile}">
+                    <File name="file" fileName="${ctx:logFile:-/dev/null}">
                         <JsonTemplateLayout eventTemplateUri="classpath:OpenEOJsonLogLayout.json"
                                             locationInfoEnabled="true"/>
                     </File>

--- a/openeo-logging/src/test/resources/log4j2-sync.xml
+++ b/openeo-logging/src/test/resources/log4j2-sync.xml
@@ -5,9 +5,9 @@
                                 locationInfoEnabled="true"/>
         </Console>
         <Routing name="route">
-            <Routes pattern="$${ctx:logFile}">
+            <Routes pattern="$${env:LOG_FILE}">
                 <Route>
-                    <File name="file" fileName="${ctx:logFile:-/dev/null}">
+                    <File name="file" fileName="${env:LOG_FILE}">
                         <JsonTemplateLayout eventTemplateUri="classpath:OpenEOJsonLogLayout.json"
                                             locationInfoEnabled="true"/>
                     </File>

--- a/openeo-logging/src/test/scala/org/openeo/logging/OpenEOBatchJobJsonLogLayoutTest.scala
+++ b/openeo-logging/src/test/scala/org/openeo/logging/OpenEOBatchJobJsonLogLayoutTest.scala
@@ -4,9 +4,10 @@ import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkContext
 import org.junit.Assert.assertTrue
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.rules.TemporaryFolder
 import org.junit.{AfterClass, Before, BeforeClass, Rule, Test}
-import org.slf4j.{LoggerFactory, MDC}
+import org.slf4j.LoggerFactory
 
 import java.io.File
 import scala.annotation.meta.getter
@@ -27,11 +28,13 @@ class OpenEOBatchJobJsonLogLayoutTest {
 
   @(Rule @getter)
   val temporaryFolder = new TemporaryFolder
-
   private def tempLogFile: File = new File(temporaryFolder.getRoot, "openeo.log")
 
+  @(Rule @getter)
+  val environmentVariables = new EnvironmentVariables
+
   @Before
-  def setupLogFile(): Unit = MDC.put("logFile", tempLogFile.getAbsolutePath)
+  def setupLogFile(): Unit = environmentVariables.set("LOG_FILE", tempLogFile.getAbsolutePath)
 
   @Test
   def testJsonLogging(): Unit = {
@@ -54,7 +57,6 @@ class OpenEOBatchJobJsonLogLayoutTest {
     try {
       sc.range(1, 100)
         .mapPartitions { is =>
-          MDC.put("logFile", logFile.getAbsolutePath)
           logger.info("some executor log")
           is
         }
@@ -67,6 +69,33 @@ class OpenEOBatchJobJsonLogLayoutTest {
     assertTrue(s"${executorLogEntries.size}", executorLogEntries.nonEmpty)
     assertTrue(executorLogEntries.forall { logEntry =>
       logEntry("user_id").asString.contains("vdboschj") && logEntry("job_id").asString.contains("j-abc123")
+    })
+  }
+
+  @Test
+  def testError(): Unit = {
+    val sc = new SparkContext(master = "local[1]", appName = getClass.getName)
+    val data = sc.parallelize(Seq(1, 2, 3, 4, 5))
+    try {
+      data.map(x => {
+        if (x == 3) {
+          throw new Exception("Intentional exception")
+        } else {
+          x * 2
+        }
+      }).collect()
+    } catch {
+      case e: Exception =>
+        println(e) // Ignore error
+    }
+    finally sc.stop()
+
+    val executorLogEntries = Helpers.logEntries(tempLogFile)
+    assertTrue(executorLogEntries.forall { logEntry =>
+      logEntry("user_id").asString.contains("vdboschj") && logEntry("job_id").asString.contains("j-abc123")
+    })
+    assertTrue(executorLogEntries.exists { logEntry =>
+      logEntry("name").asString.contains("org.apache.spark.scheduler.TaskSetManager")
     })
   }
 }


### PR DESCRIPTION
Logs from Spark UI etc. were written to a file actually called ${ctx:logFile}.

https://github.com/Open-EO/openeo-geopyspark-driver/issues/429