### PR TITLE
support udf's that change spatial resolution of the datacube

### DIFF
--- a/geotrellis-integrationtests/pom.xml
+++ b/geotrellis-integrationtests/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>black.ninia</groupId>
             <artifactId>jep</artifactId>
-            <version>3.9.1</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/openeo-geotrellis/pom.xml
+++ b/openeo-geotrellis/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>black.ninia</groupId>
             <artifactId>jep</artifactId>
-            <version>3.9.1</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
@@ -295,7 +295,7 @@ object Udf {
     // and then slice it!
 
     val newLayout = {
-      if (code.contains("convert_dimensions")) {
+      if (code.contains("apply_metadata")) {
         val newResolution = 5.0 //TODO determine based on convert_dimensions
         val crsCode = layer.metadata.crs.epsgCode.get
         val stepSize = layer.metadata.layout.cellSize
@@ -316,7 +316,7 @@ object Udf {
             _setContextInPython(interp, context)
             interp.exec(code)
             interp.exec(cubeMetadata)
-            interp.exec("result_metadata = convert_dimensions(openeo.metadata.CollectionMetadata(metadata), context)")
+            interp.exec("result_metadata = apply_metadata(openeo.metadata.CollectionMetadata(metadata), context)")
             val targetResolutionX:Double = interp.getValue("result_metadata.get('x','step')").asInstanceOf[Double]
             val targetResolutionY:Double = interp.getValue("result_metadata.get('y','step')").asInstanceOf[Double]
             CellSize(targetResolutionX,targetResolutionY)
@@ -386,7 +386,9 @@ object Udf {
                 }
                 val dtype = interp.getValue("str(result_cube.get_array().values.dtype)").asInstanceOf[String]
                 _checkOutputDtype(dtype)
-                _checkOutputSpatialDimensions(resultDimensions, tileRows, tileCols)
+                if(newLayout.isEmpty)
+                  _checkOutputSpatialDimensions(resultDimensions, tileRows, tileCols)
+                println(cube.getData)
 
                 FloatBuffer.wrap(cube.getData)
             }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
@@ -1,7 +1,8 @@
 package org.openeo.geotrellis.udf
 
 import geotrellis.layer.{LayoutDefinition, SpaceTimeKey, SpatialKey, TemporalProjectedExtent}
-import geotrellis.raster.{ArrayMultibandTile, FloatArrayTile, MultibandTile}
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.raster.{ArrayMultibandTile, CellSize, FloatArrayTile, FloatConstantNoDataCellType, MultibandTile, RasterExtent}
 import geotrellis.spark.{ContextRDD, MultibandTileLayerRDD, withTilerMethods}
 import geotrellis.vector.{Extent, MultiPolygon, ProjectedExtent}
 import jep.{DirectNDArray, JepConfig, NDArray, SharedInterpreter}
@@ -35,7 +36,7 @@ object Udf {
   private def _createSharedInterpreter(): SharedInterpreter = {
     if (!isInterpreterInitialized) {
       val config = new JepConfig()
-      config.setRedirectOutputStreams(true)
+      //config.setRedirectOutputStreams(true)
       SharedInterpreter.setConfig(config)
       isInterpreterInitialized = true
     }
@@ -292,11 +293,49 @@ object Udf {
 
     // TODO: AllocateDirect is an expensive operation, we should create one buffer for the entire partition
     // and then slice it!
+
+    val newLayout = {
+      if (code.contains("convert_dimensions")) {
+        val newResolution = 5.0 //TODO determine based on convert_dimensions
+        val crsCode = layer.metadata.crs.epsgCode.get
+        val stepSize = layer.metadata.layout.cellSize
+        val cubeMetadata =
+          s"""
+            |import openeo.metadata
+            |metadata = {
+            |      "x": {"type": "spatial", "axis": "x", "step": ${stepSize.width}, "reference_system": $crsCode},
+            |      "y": {"type": "spatial", "axis": "y", "step": ${stepSize.height}, "reference_system": $crsCode},
+            |      "t": {"type": "temporal"}
+            |}
+            |
+            |""".stripMargin
+        val resultMetadata = layer.sparkContext.parallelize(Seq(1)).map(t=>{
+          val interp = _createSharedInterpreter()
+          try {
+            interp.exec(DEFAULT_IMPORTS)
+            _setContextInPython(interp, context)
+            interp.exec(code)
+            interp.exec(cubeMetadata)
+            interp.exec("result_metadata = convert_dimensions(openeo.metadata.CollectionMetadata(metadata), context)")
+            val targetResolutionX:Double = interp.getValue("result_metadata.get('x','step')").asInstanceOf[Double]
+            val targetResolutionY:Double = interp.getValue("result_metadata.get('y','step')").asInstanceOf[Double]
+            CellSize(targetResolutionX,targetResolutionY)
+          } finally if (interp != null) interp.close()
+        }).collect()
+
+        Some(LayoutDefinition(RasterExtent(layer.metadata.layout.extent, resultMetadata.apply(0)), layer.metadata.layout.tileRows))
+      } else {
+        None
+      }
+
+    }
+    val oldLayout = layer.metadata.layout
+
     val result = layer.mapPartitions(iter => {
       // TODO: Start an interpreter for every partition
       // TODO: Currently this fails because per tile processing cannot access the interpreter
       // TODO: This is because every tile in a partition is handled in a separate thread.
-      iter.map(key_and_tile => {
+      iter.flatMap(key_and_tile => {
         val multiBandTile: MultibandTile = key_and_tile._2
         val tileRows = multiBandTile.bands(0).rows
         val tileCols = multiBandTile.bands(0).cols
@@ -332,24 +371,25 @@ object Udf {
           // Convert the result back to a MultibandTile.
           val resultDimensions = interp.getValue("result_cube.get_array().values.shape").asInstanceOf[java.util.List[Long]].asScala.toList.map(_.toInt)
           val resultCube = interp.getValue("result_cube.get_array().values")
-          var resultBuffer: FloatBuffer = null
-          resultCube match {
-            case cube: DirectNDArray[FloatBuffer] =>
-              // The datacube was modified inplace.
-              resultBuffer = cube.getData
-            case cube: NDArray[Array[Float]] =>
-              // UDF created a new datacube.
-              if (resultDimensions.length < 2) {
-                throw new IllegalArgumentException((
-                  "UDF returned a datacube that has less than 2 dimensions. " +
-                    "Actual dimensions: (%s).").format(resultDimensions.mkString(", "))
-                )
-              }
-              val dtype = interp.getValue("str(result_cube.get_array().values.dtype)").asInstanceOf[String]
-              _checkOutputDtype(dtype)
-              _checkOutputSpatialDimensions(resultDimensions, tileRows, tileCols)
-              resultBuffer = FloatBuffer.wrap(cube.getData)
-          }
+          val resultBuffer: FloatBuffer =
+            resultCube match {
+              case cube: DirectNDArray[FloatBuffer] =>
+                // The datacube was modified inplace.
+                cube.getData
+              case cube: NDArray[Array[Float]] =>
+                // UDF created a new datacube.
+                if (resultDimensions.length < 2) {
+                  throw new IllegalArgumentException((
+                    "UDF returned a datacube that has less than 2 dimensions. " +
+                      "Actual dimensions: (%s).").format(resultDimensions.mkString(", "))
+                  )
+                }
+                val dtype = interp.getValue("str(result_cube.get_array().values.dtype)").asInstanceOf[String]
+                _checkOutputDtype(dtype)
+                _checkOutputSpatialDimensions(resultDimensions, tileRows, tileCols)
+
+                FloatBuffer.wrap(cube.getData)
+            }
 
           // UDFs can
           //  * add/remove band coordinates but not rows, cols.
@@ -369,10 +409,28 @@ object Udf {
           resultMultiBandTile = _extractMultibandTileFromBuffer(resultBuffer, newNumberOfBands, tileSize, tileCols, tileRows)
         } finally if (interp != null) interp.close()
 
-        (key_and_tile._1, resultMultiBandTile)
-      })
-    }, preservesPartitioning = true)
+        if (newLayout.isDefined) {
+          var newExtent: Extent = key_and_tile._1.spatialKey.extent(oldLayout) //TODO: don't assume that extent stays the same, but determine extent of the output based on result XArray Coords
+          newLayout.get.mapTransform(newExtent)
+            .coordsIter
+            .map { spatialComponent =>
+              val outKey: SpatialKey = spatialComponent
 
-    ContextRDD(result, layer.metadata)
+              val newTile = multiBandTile.prototype(FloatConstantNoDataCellType, tileCols, tileRows)
+              (SpaceTimeKey(outKey,key_and_tile._1.time), newTile.merge(
+                newLayout.get.mapTransform.keyToExtent(outKey),
+                newExtent,
+                resultMultiBandTile,
+                NearestNeighbor
+              ))
+            }
+        }else{
+          Some((key_and_tile._1, resultMultiBandTile))
+        }
+
+      })
+    }, preservesPartitioning = newLayout.isEmpty)
+
+    ContextRDD(result, layer.metadata.copy(layout=newLayout.getOrElse(layer.metadata.layout)))
   }
 }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/udf/Udf.scala
@@ -36,7 +36,8 @@ object Udf {
   private def _createSharedInterpreter(): SharedInterpreter = {
     if (!isInterpreterInitialized) {
       val config = new JepConfig()
-      //config.setRedirectOutputStreams(true)
+      config.redirectStdErr(System.err)
+      config.redirectStdout(System.out)
       SharedInterpreter.setConfig(config)
       isInterpreterInitialized = true
     }

--- a/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/modify_spatial_dimensions.py
+++ b/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/modify_spatial_dimensions.py
@@ -1,0 +1,17 @@
+import xarray
+from openeo.udf import XarrayDataCube
+
+
+def convert_dimensions(metadata, context:dict):
+    from openeo.metadata import CollectionMetadata
+    new_metadata = {
+          "x": {"type": "spatial", "axis": "x", "step": 0.3, "reference_system": 4326},
+          "y": {"type": "spatial", "axis": "y", "step": 0.3, "reference_system": 4326},
+          "t": {"type": "temporal"}
+    }
+    return CollectionMetadata(new_metadata)
+
+def apply_datacube(cube: XarrayDataCube, context: dict) -> XarrayDataCube:
+    array: xarray.DataArray = cube.get_array()
+    array += 60
+    return XarrayDataCube(array)

--- a/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/modify_spatial_dimensions.py
+++ b/openeo-geotrellis/src/test/resources/org/openeo/geotrellis/udf/modify_spatial_dimensions.py
@@ -1,17 +1,43 @@
 import xarray
 from openeo.udf import XarrayDataCube
+from openeo.udf.debug import inspect
+from openeo.metadata import CollectionMetadata
 
+def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
 
-def convert_dimensions(metadata, context:dict):
-    from openeo.metadata import CollectionMetadata
+    xstep = input_metadata.get('x','step')
+    ystep = input_metadata.get('y','step')
     new_metadata = {
-          "x": {"type": "spatial", "axis": "x", "step": 0.3, "reference_system": 4326},
-          "y": {"type": "spatial", "axis": "y", "step": 0.3, "reference_system": 4326},
+          "x": {"type": "spatial", "axis": "x", "step": xstep/2.0, "reference_system": 4326},
+          "y": {"type": "spatial", "axis": "y", "step": ystep/2.0, "reference_system": 4326},
           "t": {"type": "temporal"}
     }
     return CollectionMetadata(new_metadata)
 
+def fancy_upsample_function(array: np.array, factor: int = 2) -> np.array:
+    assert array.ndim == 3
+    return array.repeat(factor, axis=-1).repeat(factor, axis=-2)
+
 def apply_datacube(cube: XarrayDataCube, context: dict) -> XarrayDataCube:
     array: xarray.DataArray = cube.get_array()
-    array += 60
-    return XarrayDataCube(array)
+
+    cubearray: xarray.DataArray = cube.get_array().copy() + 60
+
+    # We make prediction and transform numpy array back to datacube
+
+    # Pixel size of the original image
+    init_pixel_size_x = cubearray.coords['x'][-1] - cubearray.coords['x'][-2]
+    init_pixel_size_y = cubearray.coords['y'][-1] - cubearray.coords['y'][-2]
+
+    if cubearray.data.ndim == 4 and cubearray.data.shape[0] == 1:
+        cubearray = cubearray[0]
+    predicted_array = fancy_upsample_function(cubearray.data, 2)
+    inspect(predicted_array, "test message")
+    coord_x = np.linspace(start=cube.get_array().coords['x'].min(), stop=cube.get_array().coords['x'].max() + init_pixel_size_x,
+                          num=predicted_array.shape[-2], endpoint=False)
+    coord_y = np.linspace(start=cube.get_array().coords['y'].min(), stop=cube.get_array().coords['y'].max() + init_pixel_size_y,
+                          num=predicted_array.shape[-1], endpoint=False)
+    predicted_cube = xarray.DataArray(predicted_array, dims=['bands', 'x', 'y'], coords=dict(x=coord_x, y=coord_y))
+
+
+    return XarrayDataCube(predicted_cube)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
@@ -3,14 +3,15 @@ package org.openeo.geotrellis.udf
 import geotrellis.layer.{Bounds, KeyBounds, Metadata, SpaceTimeKey, SpatialKey, TemporalKey, TileLayerMetadata}
 import geotrellis.raster.geotiff.GeoTiffRasterSource
 import geotrellis.raster.testkit.RasterMatchers
-import geotrellis.raster.{ArrayMultibandTile, FloatArrayTile, MultibandTile, MutableArrayTile, Tile, TileLayout}
+import geotrellis.raster.{ArrayMultibandTile, CellSize, FloatArrayTile, MultibandTile, Tile, TileLayout}
 import geotrellis.spark.testkit.TileLayerRDDBuilders
 import geotrellis.spark.util.SparkUtils
 import geotrellis.spark.{ContextRDD, MultibandTileLayerRDD, _}
 import geotrellis.vector.{Extent, MultiPolygon, Polygon}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkConf, SparkContext}
-import org.junit.{AfterClass, BeforeClass}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{AfterAll, BeforeAll}
 import org.openeo.geotrellis.geotiff.saveRDD
 import org.openeo.geotrellis.{OpenEOProcesses, ProjectedPolygons}
 
@@ -22,16 +23,16 @@ import scala.io.Source
 object UdfTest {
   private var sc: SparkContext = _
 
-  @BeforeClass
+  @BeforeAll
   def setupSpark(): Unit = {
     val sparkConf = new SparkConf()
       .set("spark.kryoserializer.buffer.max", "512m")
       .set("spark.rdd.compress","true")
 
-    sc = SparkUtils.createLocalSparkContext("local[*]", classOf[UdfTest].getName, sparkConf)
+    sc = SparkUtils.createLocalSparkContext("local[1]", classOf[UdfTest].getName, sparkConf)
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownSpark(): Unit = sc.stop()
 }
 
@@ -52,7 +53,7 @@ class UdfTest extends RasterMatchers {
     Supported CellTypes: Float
     Unsupported CellTypes: Bit, Byte, Ubyte, Short, UShort, Int, Float, Double
    */
-//  @Test
+  //@Test
   def testSimpleDatacubeOperationsFloat(): Unit = {
     val filename = "/org/openeo/geotrellis/udf/simple_datacube_operations.py"
     val source = Source.fromURL(getClass.getResource(filename))
@@ -63,6 +64,21 @@ class UdfTest extends RasterMatchers {
     val datacube: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]] = _createChunkPolygonDatacube(dates)
     datacube.values.first().bands(0).foreach(e => assert(e == 0))
     val resultRDD = Udf.runUserCode(code, datacube, new util.ArrayList[String](), new util.HashMap[String, Any]())
+    resultRDD.values.first().bands(0).foreach(e => assert(e == 60))
+  }
+
+  //@Test
+  def testSuperResolution(): Unit = {
+    val filename = "/org/openeo/geotrellis/udf/modify_spatial_dimensions.py"
+    val source = Source.fromURL(getClass.getResource(filename))
+    val code = source.getLines.mkString("\n")
+    source.close()
+
+    val dates = _getDates()
+    val datacube: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]] = _createChunkPolygonDatacube(dates)
+    datacube.values.first().bands(0).foreach(e => assert(e == 0))
+    val resultRDD = Udf.runUserCode(code, datacube, new util.ArrayList[String](), new util.HashMap[String, Any]())
+    assertEquals(resultRDD.metadata.layout.cellSize,CellSize(0.3,0.3))
     resultRDD.values.first().bands(0).foreach(e => assert(e == 60))
   }
 

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/udf/UdfTest.scala
@@ -11,7 +11,7 @@ import geotrellis.vector.{Extent, MultiPolygon, Polygon}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkConf, SparkContext}
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.{AfterAll, BeforeAll}
+import org.junit.jupiter.api.{AfterAll, BeforeAll, Test}
 import org.openeo.geotrellis.geotiff.saveRDD
 import org.openeo.geotrellis.{OpenEOProcesses, ProjectedPolygons}
 
@@ -76,10 +76,13 @@ class UdfTest extends RasterMatchers {
 
     val dates = _getDates()
     val datacube: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]] = _createChunkPolygonDatacube(dates)
+    val currentRes = datacube.metadata.cellSize
     datacube.values.first().bands(0).foreach(e => assert(e == 0))
     val resultRDD = Udf.runUserCode(code, datacube, new util.ArrayList[String](), new util.HashMap[String, Any]())
-    assertEquals(resultRDD.metadata.layout.cellSize,CellSize(0.3,0.3))
+    assertEquals(resultRDD.metadata.layout.cellSize,CellSize(currentRes.width/2.0,currentRes.height/2.0))
+    assertEquals(datacube.metadata.cols*2,resultRDD.metadata.cols)
     resultRDD.values.first().bands(0).foreach(e => assert(e == 60))
+
   }
 
   def _getDates(): Seq[ZonedDateTime] = {


### PR DESCRIPTION
Allow a UDF that transforms datacube spatial dimensions, to support cases like custom upsampling of the data.
A new udf signature is introduced that transforms the metadata itself. This allows the backend to determine updated cube metadata, without running the actual UDF.

https://github.com/Open-EO/openeo-geopyspark-driver/issues/412