### PR TITLE
Fix bandcount

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/EmptyMultibandTile.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/EmptyMultibandTile.scala
@@ -37,7 +37,7 @@ class EmptyMultibandTile(val cols:Int, val rows:Int, val cellType:CellType, val 
 
   override def band(bandIndex: Int): Tile = EmptyMultibandTile.empty(cellType, cols, rows)
 
-  override def bands: Vector[Tile] = List.fill(bandCount)(EmptyMultibandTile.empty(cellType, cols, rows)).toVector
+  override def bands: Vector[Tile] = Vector.fill(bandCount)(EmptyMultibandTile.empty(cellType, cols, rows))
 
   override def subsetBands(bandSequence: Seq[Int]): MultibandTile = new EmptyMultibandTile(cols,rows,cellType,bandSequence.size)
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/EmptyMultibandTile.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/EmptyMultibandTile.scala
@@ -37,7 +37,7 @@ class EmptyMultibandTile(val cols:Int, val rows:Int, val cellType:CellType, val 
 
   override def band(bandIndex: Int): Tile = EmptyMultibandTile.empty(cellType, cols, rows)
 
-  override def bands: Vector[Tile] = Vector[Tile]()
+  override def bands: Vector[Tile] = List.fill(bandCount)(EmptyMultibandTile.empty(cellType, cols, rows)).toVector
 
   override def subsetBands(bandSequence: Seq[Int]): MultibandTile = new EmptyMultibandTile(cols,rows,cellType,bandSequence.size)
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -459,15 +459,7 @@ class OpenEOProcesses extends Serializable {
     val rows = datacube.metadata.tileLayout.tileRows
     val cellType = datacube.metadata.cellType
 
-    //ArrayMultibandTile.empty(datacube.metadata.cellType,1,0,0)
-    val bandCount = datacube match {
-      case value: OpenEORasterCube[SpaceTimeKey] => value.openEOMetadata.bandCount
-      case _ => 0
-    }
-    val bandCount2 = RDDBandCount(datacube) // Better
-    if (bandCount != bandCount2) {
-      logger.warn("Band count difference! Could cause problems later on")
-    }
+    val bandCount = RDDBandCount(datacube)
     val filledRDD: RDD[(SpaceTimeKey, MultibandTile)] = {
       if(reduce) {
         tilesByInterval.rightOuterJoin(allKeysRDD,partitioner).mapValues(_._1.getOrElse(new EmptyMultibandTile(cols, rows, cellType, bandCount)))
@@ -780,27 +772,17 @@ class OpenEOProcesses extends Serializable {
     val rightBandCount = RDDBandCount(rightCube)
     leftCube.sparkContext.clearJobGroup()
     // Concatenation band counts are allowed to differ, but all resulting multiband tiles should have the same count
-    val retCube = new ContextRDD(joined.mapValues({
+    new ContextRDD(joined.mapValues({
       case (None, Some(r)) => MultibandTile(Vector.fill(leftBandCount)(ArrayTile.empty(r.cellType, r.cols, r.rows)) ++ r.bands)
       case (Some(l), None) => MultibandTile(l.bands ++ Vector.fill(rightBandCount)(ArrayTile.empty(l.cellType, l.cols, l.rows)))
       case (Some(l), Some(r)) => {
         if (l.bandCount != leftBandCount || r.bandCount != rightBandCount) {
-          if (l.isInstanceOf[EmptyMultibandTile]) {
-            MultibandTile(Vector.fill(leftBandCount)(ArrayTile.empty(r.cellType, r.cols, r.rows)) ++ r.bands)
-          }
-          else if (r.isInstanceOf[EmptyMultibandTile]) {
-            MultibandTile(l.bands ++ Vector.fill(rightBandCount)(ArrayTile.empty(l.cellType, l.cols, l.rows)))
-          } else {
-            throw new IllegalArgumentException(s"The number of bands in the metadata ${leftBandCount}/${rightBandCount} does not match the actual band count in the cubes (left/right): ${l.bandCount}/${r.bandCount}. You can fix this by explicitly specifying correct band labels.")
-          }
+          throw new IllegalArgumentException(s"The number of bands in the metadata ${leftBandCount}/${rightBandCount} does not match the actual band count in the cubes (left/right): ${l.bandCount}/${r.bandCount}. You can fix this by explicitly specifying correct band labels.")
         } else {
           MultibandTile(l.bands ++ r.bands)
         }
       }
     }), updatedMetadata)
-    val retCubeBandCount = RDDBandCount(retCube)
-    logger.warn("retCubeBandCount: " + retCubeBandCount)
-    retCube
   }
 
   private def resolve_merge_overlap[K](joinedRDD: RDD[(K, (Option[MultibandTile], Option[MultibandTile]))], operator: String, updatedMetadata: TileLayerMetadata[K])(implicit kt: ClassTag[K], ord: Ordering[K] = null) = {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -464,6 +464,10 @@ class OpenEOProcesses extends Serializable {
       case value: OpenEORasterCube[SpaceTimeKey] => value.openEOMetadata.bandCount
       case _ => 0
     }
+    val bandCount2 = RDDBandCount(datacube) // Better
+    if (bandCount != bandCount2) {
+      logger.warn("Band count difference! Could cause problems later on")
+    }
     val filledRDD: RDD[(SpaceTimeKey, MultibandTile)] = {
       if(reduce) {
         tilesByInterval.rightOuterJoin(allKeysRDD,partitioner).mapValues(_._1.getOrElse(new EmptyMultibandTile(cols, rows, cellType, bandCount)))

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/EmptyMultibandTileTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/EmptyMultibandTileTest.scala
@@ -25,23 +25,28 @@ object EmptyMultibandTileTest {
 }
 
 @RunWith(classOf[Parameterized])
-class EmptyMultibandTileTest(ct:CellType) {
+class EmptyMultibandTileTest(ct: CellType) {
 
   //@Parameterized.Parameter(value = 0) var ct: CellType = IntConstantNoDataCellType
-
 
 
   @Test
   def testCreateEmpty(): Unit = {
     val tile = EmptyMultibandTile.empty(ct, 10, 10)
-    assertEquals(NODATA,tile.get(0,0))
+    assertEquals(NODATA, tile.get(0, 0))
   }
 
   @Test
   def testCreate(): Unit = {
     val emptyMultibandTile: MultibandTile = new EmptyMultibandTile(10, 10, ct, 3)
     assertEquals(emptyMultibandTile.bandCount, 3)
-    assertEquals(NODATA, emptyMultibandTile.bands.head.get(0, 0))
-    assertEquals(NODATA, emptyMultibandTile.band(1).get(0, 0))
+    assertEquals(emptyMultibandTile.bands.size, 3)
+    for (band <- emptyMultibandTile.bands) {
+      // Test the corners:
+      assertEquals(NODATA, band.get(0, 0))
+      assertEquals(NODATA, band.get(0, band.rows - 1))
+      assertEquals(NODATA, band.get(band.cols - 1, 0))
+      assertEquals(NODATA, band.get(band.cols - 1, band.rows - 1))
+    }
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/EmptyMultibandTileTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/EmptyMultibandTileTest.scala
@@ -1,9 +1,8 @@
 package org.openeo.geotrellis
 
 import java.util
-
 import geotrellis.raster.CellType.constantNoDataCellTypes
-import geotrellis.raster.{CellType, FloatUserDefinedNoDataCellType, IntUserDefinedNoDataCellType, NODATA, UByteUserDefinedNoDataCellType, UShortUserDefinedNoDataCellType}
+import geotrellis.raster.{CellType, FloatUserDefinedNoDataCellType, IntUserDefinedNoDataCellType, MultibandTile, NODATA, Tile, UByteUserDefinedNoDataCellType, UShortUserDefinedNoDataCellType}
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,4 +37,11 @@ class EmptyMultibandTileTest(ct:CellType) {
     assertEquals(NODATA,tile.get(0,0))
   }
 
+  @Test
+  def testCreate(): Unit = {
+    val emptyMultibandTile: MultibandTile = new EmptyMultibandTile(10, 10, ct, 3)
+    assertEquals(emptyMultibandTile.bandCount, 3)
+    assertEquals(NODATA, emptyMultibandTile.bands.head.get(0, 0))
+    assertEquals(NODATA, emptyMultibandTile.band(1).get(0, 0))
+  }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
@@ -113,7 +113,7 @@ object LayerFixtures {
    * Returns an RDD with tiles that switch between data and noData.
    * patternScale 2 gives [0 0 T T 0 0 T T] (where 0 is noData, and T is a data tile)
    */
-  def buildSpatioTemporalDataCubePattern(tilingFactor: Int = 1, patternScale: Int = 1): ContextRDD[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]] = {
+  def buildSpatioTemporalDataCubePattern(tilingFactor: Int = 1, patternScale: Int = 1): MultibandTileLayerRDD[SpaceTimeKey] = {
     val horizontalTiles = 8
     val tilePixelSize = 16
     val tileLayout = new TileLayout(tilingFactor * horizontalTiles, tilingFactor, (tilePixelSize / tilingFactor), (tilePixelSize / tilingFactor))

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
@@ -115,7 +115,7 @@ object LayerFixtures {
    */
   def buildSpatioTemporalDataCubePattern(tilingFactor: Int = 1, patternScale: Int = 1): ContextRDD[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]] = {
     val horizontalTiles = 8
-    val tilePixelSize = 64
+    val tilePixelSize = 16
     val tileLayout = new TileLayout(tilingFactor * horizontalTiles, tilingFactor, (tilePixelSize / tilingFactor), (tilePixelSize / tilingFactor))
 
     val rand = new scala.util.Random(42) // Fixed seed to make test predictable

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/MergeCubesSpec.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/MergeCubesSpec.scala
@@ -161,9 +161,9 @@ class MergeCubesSpec {
     Files.createDirectories(Paths.get(path))
     val p = new OpenEOProcesses()
 
-    def aggregate(rdd: ContextRDD[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]],
+    def aggregate(rdd: MultibandTileLayerRDD[SpaceTimeKey],
             aggregationType: AggregationType.Value,
-           ): ContextRDD[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]] = {
+           ): MultibandTileLayerRDD[SpaceTimeKey] = {
       val startDate = rdd.keys.collect().head.time
       if (aggregationType == AggregationType.no) {
         rdd


### PR DESCRIPTION
Summary:
- Some EmptyMultibandTiles where made with 0 bands. While there should be 'n' bands
- When asking EmptyMultibandTile for a list of bands, an empty array was returned, instead of a list of 'n' empty bands.

This caused problems when combining merge_cubes and aggregate_temporal.
A test has been added that goes over many combinations of those, to filter out bugs.