### PR TITLE
Geotrellis 372

### DIFF
--- a/geotrellis-sentinelhub/pom.xml
+++ b/geotrellis-sentinelhub/pom.xml
@@ -15,7 +15,7 @@
             <!--https://github.com/typelevel/cats/issues/3628-->
             <groupId>org.typelevel</groupId>
             <artifactId>cats-kernel_${scala.binary.version}</artifactId>
-            <version>2.4.2</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.openeo</groupId>

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -5,7 +5,7 @@ import _root_.io.circe.HCursor
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.vector._
 import geotrellis.vector.io.json.{JsonCRS, JsonFeatureCollection, NamedCRS}
-import org.geotools.data.Query
+import org.geotools.api.data.Query
 import org.geotools.data.shapefile.ShapefileDataStore
 import org.geotools.data.simple.SimpleFeatureIterator
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/netcdf/NetCDFRDDWriter.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/netcdf/NetCDFRDDWriter.scala
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest
-import ucar.ma2.{ArrayDouble, ArrayInt, DataType}
+import ucar.ma2.{ArrayDouble, ArrayInt, DataType, InvalidRangeException}
 import ucar.nc2.write.Nc4ChunkingDefault
 import ucar.nc2.{Attribute, Dimension, NetcdfFileWriter, Variable}
 
@@ -759,7 +759,6 @@ object NetCDFRDDWriter {
     if (coordinates != null) netcdfFile.addVariableAttribute(variableName, "coordinates", coordinates)
   }
 
-  import org.opengis.coverage.grid.InvalidRangeException
 
   @throws[IOException]
   @throws[InvalidRangeException]

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
                 <module>geotrellis-s3-extensions</module>
                 <module>geotrellis-sentinelhub</module>
                 <module>geotrellis-extensions</module>
-                <module>geotrellis-seeder</module>
                 <module>openeo-geotrellis</module>
                 <module>geotrellis-benchmarks</module>
                 <module>geotrellis-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <spark.version>3.4.2</spark.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.18</scala.version>
-        <geotrellis.version>3.6.0</geotrellis.version>
+        <geotrellis.version>3.7.1+16-24f62711-SNAPSHOT</geotrellis.version>
         <gdal-bindings.version>3.8.0</gdal-bindings.version>
         <commons-compress-version>1.10</commons-compress-version>
         <gwc-geotrellis.version>0.17.0_2.12-SNAPSHOT</gwc-geotrellis.version>
@@ -209,6 +209,13 @@
         <repository>
             <id>artifactory-snapshot</id>
             <url>https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>openeo-geotrellis-extensions</name>
     <properties>
-        <gt-version>21.2</gt-version>
+        <gt-version>31.0</gt-version>
         <hadoop.version>3.1.1</hadoop.version>
         <avro.version>1.7.7</avro.version>
         <spark.version>3.4.2</spark.version>
@@ -51,8 +51,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>geotrellis-accumulo-extensions</module>
-                <module>geotrellis-s3-extensions</module>
                 <module>geotrellis-sentinelhub</module>
                 <module>geotrellis-extensions</module>
                 <module>openeo-geotrellis</module>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <gdal-bindings.version>3.8.0</gdal-bindings.version>
         <commons-compress-version>1.10</commons-compress-version>
         <gwc-geotrellis.version>0.17.0_2.12-SNAPSHOT</gwc-geotrellis.version>
-        <openeo-opensearch-client.version>1.4.0_2.12-SNAPSHOT</openeo-opensearch-client.version>
+        <openeo-opensearch-client.version>1.5.0_2.12-SNAPSHOT</openeo-opensearch-client.version>
         <awssdk.version>2.21.26</awssdk.version>
         <jaxb.api.version>2.3.0</jaxb.api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Integrate new geotrellis.
Works, but some tests indicate changes:
[org.openeo.geotrellis.OpenEOProcessesSpec.testGroupAndMaskByGeometry](https://jenkins.vgt.vito.be/job/openEO/job/openeo-geotrellis-extensions/job/geotrellis_372/13/testReport/junit/org.openeo.geotrellis/OpenEOProcessesSpec/testGroupAndMaskByGeometry/)
[org.openeo.geotrellis.layers.AgEra5FileLayerProviderTest.agEra5FileLayerProvider](https://jenkins.vgt.vito.be/job/openEO/job/openeo-geotrellis-extensions/job/geotrellis_372/13/testReport/junit/org.openeo.geotrellis.layers/AgEra5FileLayerProviderTest/agEra5FileLayerProvider/)
[org.openeo.geotrellis.layers.Sentinel2FileLayerProviderTest.multibandWithSpacetimeMask{DataCubeParameters, int}[1]](https://jenkins.vgt.vito.be/job/openEO/job/openeo-geotrellis-extensions/job/geotrellis_372/13/testReport/junit/org.openeo.geotrellis.layers/Sentinel2FileLayerProviderTest/multibandWithSpacetimeMask_DataCubeParameters__int__1_/)
[org.openeo.geotrellis.layers.Sentinel2FileLayerProviderTest.multibandWithSpacetimeMask{DataCubeParameters, int}[2]](https://jenkins.vgt.vito.be/job/openEO/job/openeo-geotrellis-extensions/job/geotrellis_372/13/testReport/junit/org.openeo.geotrellis.layers/Sentinel2FileLayerProviderTest/multibandWithSpacetimeMask_DataCubeParameters__int__2_/)