### PR TITLE
355 mergecubes uses default geotrellis partitioner in certain cases which causes oom errors

### DIFF
--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
@@ -4,6 +4,7 @@ import geotrellis.layer.{SpaceTimeKey, SpatialKey}
 import geotrellis.spark.partition.PartitionerIndex
 import geotrellis.store.index.KeyIndex
 import org.apache.spark.Partitioner
+import org.locationtech.sfcurve.IndexRange
 import org.locationtech.sfcurve.zorder.{Z2, ZRange}
 import org.openeo.geotrelliscommon.zcurve.SfCurveZSpaceTimeKeyIndex
 
@@ -157,20 +158,21 @@ package object geotrelliscommon {
       Z2.zranges(ZRange(toZ(keyRange._1), toZ(keyRange._2))).map(t=> (BigInt.long2bigInt(t.lower),BigInt.long2bigInt(t.upper)))
   }
 
-  class ConfigurableSpaceTimePartitioner ( val indexReduction:Int = SpaceTimeByMonthPartitioner.DEFAULT_INDEX_REDUCTION, val keyIndex: KeyIndex[SpaceTimeKey] = SfCurveZSpaceTimeKeyIndex.byDay(null) )  extends PartitionerIndex[SpaceTimeKey] {
-
-
-    def toIndex(key: SpaceTimeKey): BigInt = keyIndex.toIndex(key) >> indexReduction
-
-    def indexRanges(keyRange: (SpaceTimeKey, SpaceTimeKey)): Seq[(BigInt, BigInt)] = {
-      val originalRanges = keyIndex.indexRanges(keyRange)
-
-      val mappedRanges = originalRanges.map(range => (range._1 >> indexReduction, (range._2 >> indexReduction)))
+  object ConfigurableSpatialPartitionerReduceZ {
+    /**
+     * Maps a sequence of index ranges by applying a reduction to their values, and filters out redundant ranges.
+     *
+     * @param originalRanges A sequence of tuples where each tuple represents a range with a start and an end value.
+     * @param indexReduction The number of bits to reduce from each index value in the ranges.
+     * @return A sequence of distinct and filtered ranges after applying the index reduction.
+     */
+    def mapIndexRangeWithReduction(originalRanges: Seq[(BigInt, BigInt)], indexReduction: Int): Seq[(BigInt, BigInt)] = {
+      val mappedRanges: Seq[(BigInt, BigInt)] = originalRanges.map(range => (range._1 >> indexReduction, (range._2 >> indexReduction)))
 
       val distinct = mappedRanges.distinct
       var previousEnd: BigInt = null
 
-      //filter out regions that only span 1 value, and are already included in another region, so basically duplicates
+      // Filter out regions that only span 1 value, and are already included in another region, so basically duplicates
       var lookAheadIndex = 0
       val filtered = distinct.filter(range => {
         lookAheadIndex += 1
@@ -189,7 +191,32 @@ package object geotrelliscommon {
       })
       return filtered
     }
+  }
 
+  class ConfigurableSpatialPartitionerReduceZ(val indexReduction:Int = 2) extends PartitionerIndex[SpatialKey] {
+    // Identical to ConfigurableSpatialPartitioner but indexReduction is applied on toZ()'s output.
+    // This allows you to specify the maximum amount of records in powers of two rather than powers of four.
+    private def toZ(key: SpatialKey): Z2 = Z2(key.col, key.row)
+
+    def toIndex(key: SpatialKey): BigInt = toZ(key).z >> indexReduction
+
+    def indexRanges(keyRange: (SpatialKey, SpatialKey)): Seq[(BigInt, BigInt)] = {
+      val originalZRanges: Seq[IndexRange] = Z2.zranges(ZRange(toZ(keyRange._1), toZ(keyRange._2)))
+      val originalRanges: Seq[(BigInt, BigInt)] = originalZRanges.map(t => (BigInt.long2bigInt(t.lower), BigInt.long2bigInt(t.upper)))
+      return ConfigurableSpatialPartitionerReduceZ.mapIndexRangeWithReduction(originalRanges, indexReduction)
+    }
+  }
+
+  class ConfigurableSpaceTimePartitioner ( val indexReduction:Int = SpaceTimeByMonthPartitioner.DEFAULT_INDEX_REDUCTION, val keyIndex: KeyIndex[SpaceTimeKey] = SfCurveZSpaceTimeKeyIndex.byDay(null) )  extends PartitionerIndex[SpaceTimeKey] {
+
+    // No matter if keyIndex is by day or by month, the indexReduction decides the maximum records per partition.
+    // A higher temporal resolution means a lower spatial resolution and vice versa.
+    def toIndex(key: SpaceTimeKey): BigInt = keyIndex.toIndex(key) >> indexReduction
+
+    def indexRanges(keyRange: (SpaceTimeKey, SpaceTimeKey)): Seq[(BigInt, BigInt)] = {
+      val originalRanges = keyIndex.indexRanges(keyRange)
+      return ConfigurableSpatialPartitionerReduceZ.mapIndexRangeWithReduction(originalRanges, indexReduction)
+    }
   }
 
   implicit object SpaceTimeByMonthPartitioner extends PartitionerIndex[SpaceTimeKey] {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -730,11 +730,16 @@ class OpenEOProcesses extends Serializable {
     } else {
       // At least one partitioner is undefined.
       logger.info(s"Merging cubes with partitioners: ${leftCube.partitioner} - ${rightCube.partitioner} - many band case detected: $manyBands")
-      val nrBands = leftCount.getOrElse(1) + rightCount.getOrElse(1)
-      val outputCellType = maybeCellType(leftCube).getOrElse(DoubleCellType).union(maybeCellType(rightCube).getOrElse(DoubleCellType))
-      val tileSize = maybeTileSize(leftCube).getOrElse(128*128)
-      val newIndex = getPartitionerIndexForMaxPartitionSize[K](nrBands, tileSize, outputCellType.bits)
-      SpacePartitioner[K](kb)(implicitly, implicitly, newIndex)
+      if(manyBands) {
+        val index: PartitionerIndex[K] = getManyBandsIndexGeneric[K]()
+        SpacePartitioner[K](kb)(implicitly,implicitly,index)
+      } else {
+        val nrBands = leftCount.getOrElse(1) + rightCount.getOrElse(1)
+        val outputCellType = maybeCellType(leftCube).getOrElse(DoubleCellType).union(maybeCellType(rightCube).getOrElse(DoubleCellType))
+        val tileSize = maybeTileSize(leftCube).getOrElse(128 * 128)
+        val newIndex = getPartitionerIndexForMaxPartitionSize[K](nrBands, tileSize, outputCellType.bits)
+        SpacePartitioner[K](kb)(implicitly, implicitly, newIndex)
+      }
     }
 
     val joinRdd =
@@ -749,6 +754,16 @@ class OpenEOProcesses extends Serializable {
         }.asInstanceOf[RDD[(K, (Option[MultibandTile], Option[MultibandTile]))]]
 
     ContextRDD(joinRdd, part.bounds)
+  }
+
+  def getManyBandsIndexGeneric[K]()(implicit t:ClassTag[K]):PartitionerIndex[K] = {
+    import reflect.ClassTag
+    val spacetimeKeyTag = classOf[SpaceTimeKey]
+    val index: PartitionerIndex[K] = t match {
+      case strtag if strtag == ClassTag(spacetimeKeyTag) => SpaceTimeByMonthPartitioner.asInstanceOf[PartitionerIndex[K]]
+      case _ => ByTileSpatialPartitioner.asInstanceOf[PartitionerIndex[K]]
+    }
+    index
   }
 
   def maybeBandCount[K](cube: RDD[(K, MultibandTile)]): Option[Int] = {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -93,6 +93,15 @@ object OpenEOProcesses{
     applyToTimeseries
   }
 
+  /**
+   * Determines the appropriate partitioner index for the maximum partition size based on the input parameters.
+   *
+   * @param nrBands              The number of bands in the tile.
+   * @param tileSize             The size of the tile in number of pixels (cols*rows).
+   * @param cellTypeBits         The number of bits used for the cell type (e.g., 8 for Byte, 16 for Short, etc.).
+   * @param maxPartitionSizeInMb The maximum size of each partition in megabytes. Default is 500.0 MB.
+   * @return A partitioner index of type `PartitionerIndex[K]` tailored to ensure the partitions adhere to the specified maximum size.
+   */
   def getPartitionerIndexForMaxPartitionSize[K](nrBands: Int, tileSize: Int, cellTypeBits: Int, maxPartitionSizeInMb: Double = 500.0)(implicit t:ClassTag[K]): PartitionerIndex[K] = {
     // Estimate the maximum amount of records required to hit maxPartitionSizeInMb,
     // then calculate the max indexReduction that remains under this amount of records.

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -27,7 +27,7 @@ import org.apache.spark.{Partitioner, SparkContext}
 import org.openeo.geotrellis.OpenEOProcessScriptBuilder.{MaxIgnoreNoData, MinIgnoreNoData, OpenEOProcess, safeConvert}
 import org.openeo.geotrellis.focal._
 import org.openeo.geotrellis.netcdf.NetCDFRDDWriter.ContextSeq
-import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, ByTileSpatialPartitioner, ConfigurableSpaceTimePartitioner, DatacubeSupport, FFTConvolve, OpenEORasterCube, OpenEORasterCubeMetadata, SCLConvolutionFilter, SpaceTimeByMonthPartitioner, SparseSpaceOnlyPartitioner, SparseSpaceTimePartitioner, SparseSpatialPartitioner}
+import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, ByTileSpatialPartitioner, ConfigurableSpaceTimePartitioner, ConfigurableSpatialPartitionerReduceZ, DatacubeSupport, FFTConvolve, OpenEORasterCube, OpenEORasterCubeMetadata, SCLConvolutionFilter, SpaceTimeByMonthPartitioner, SparseSpaceOnlyPartitioner, SparseSpaceTimePartitioner, SparseSpatialPartitioner}
 import org.slf4j.LoggerFactory
 
 import java.io.File
@@ -92,8 +92,19 @@ object OpenEOProcesses{
     }
     applyToTimeseries
   }
-}
 
+  def getPartitionerIndexForMaxPartitionSize[K](nrBands: Int, tileSize: Int, cellTypeBits: Int, maxPartitionSizeInMb: Double = 500.0)(implicit t:ClassTag[K]): PartitionerIndex[K] = {
+    // Estimate the maximum amount of records required to hit maxPartitionSizeInMb,
+    // then calculate the max indexReduction that remains under this amount of records.
+    val tileSizeInMb: Double = (nrBands * tileSize * cellTypeBits).toDouble / (8 * 1024 * 1024)
+    val maxRecordsPerPartition: Double = math.min(maxPartitionSizeInMb / tileSizeInMb, 1024)
+    val indexReduction = math.ceil(math.log(maxRecordsPerPartition) / math.log(2)).toInt
+    t match {
+      case spaceTag if spaceTag == ClassTag(classOf[SpatialKey]) => new ConfigurableSpatialPartitionerReduceZ(indexReduction).asInstanceOf[PartitionerIndex[K]]
+      case _ => new ConfigurableSpaceTimePartitioner(indexReduction).asInstanceOf[PartitionerIndex[K]]
+    }
+  }
+}
 
 class OpenEOProcesses extends Serializable {
 
@@ -708,14 +719,13 @@ class OpenEOProcesses extends Serializable {
         SpacePartitioner[K](kb)
       }
     } else {
+      // At least one partitioner is undefined.
       logger.info(s"Merging cubes with partitioners: ${leftCube.partitioner} - ${rightCube.partitioner} - many band case detected: $manyBands")
-      if(manyBands) {
-        val index: PartitionerIndex[K] = getManyBandsIndexGeneric[K]()
-        SpacePartitioner[K](kb)(implicitly,implicitly,index)
-      }else{
-        SpacePartitioner[K](kb)
-      }
-
+      val nrBands = leftCount.getOrElse(1) + rightCount.getOrElse(1)
+      val outputCellType = maybeCellType(leftCube).getOrElse(DoubleCellType).union(maybeCellType(rightCube).getOrElse(DoubleCellType))
+      val tileSize = maybeTileSize(leftCube).getOrElse(128)
+      val newIndex = getPartitionerIndexForMaxPartitionSize[K](nrBands, tileSize, outputCellType.bits)
+      SpacePartitioner[K](kb)(implicitly, implicitly, newIndex)
     }
 
     val joinRdd =
@@ -731,17 +741,6 @@ class OpenEOProcesses extends Serializable {
 
     ContextRDD(joinRdd, part.bounds)
   }
-
-  def getManyBandsIndexGeneric[K]()(implicit t:ClassTag[K]):PartitionerIndex[K] = {
-    import reflect.ClassTag
-    val spacetimeKeyTag = classOf[SpaceTimeKey]
-    val index: PartitionerIndex[K] = t match {
-      case strtag if strtag == ClassTag(spacetimeKeyTag) => SpaceTimeByMonthPartitioner.asInstanceOf[PartitionerIndex[K]]
-      case _ => ByTileSpatialPartitioner.asInstanceOf[PartitionerIndex[K]]
-    }
-    index
-  }
-
 
   def maybeBandCount[K](cube: RDD[(K, MultibandTile)]): Option[Int] = {
     if (cube.isInstanceOf[OpenEORasterCube[K]] && cube.asInstanceOf[OpenEORasterCube[K]].openEOMetadata.bandCount > 0) {
@@ -760,6 +759,20 @@ class OpenEOProcesses extends Serializable {
     }else{
       return None
     }
+  }
+
+  def maybeCellType[K](cube: RDD[(K, MultibandTile)]): Option[CellType] = {
+    if (cube.isInstanceOf[MultibandTileLayerRDD[K]]) {
+      return Some(cube.asInstanceOf[MultibandTileLayerRDD[K]].metadata.cellType)
+    }
+    return None
+  }
+
+  def maybeTileSize[K](cube: RDD[(K, MultibandTile)]): Option[Int] = {
+    if (cube.isInstanceOf[MultibandTileLayerRDD[K]]) {
+      return Some(cube.asInstanceOf[MultibandTileLayerRDD[K]].metadata.tileLayout.tileSize)
+    }
+    return None
   }
 
   /**

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -723,7 +723,7 @@ class OpenEOProcesses extends Serializable {
       logger.info(s"Merging cubes with partitioners: ${leftCube.partitioner} - ${rightCube.partitioner} - many band case detected: $manyBands")
       val nrBands = leftCount.getOrElse(1) + rightCount.getOrElse(1)
       val outputCellType = maybeCellType(leftCube).getOrElse(DoubleCellType).union(maybeCellType(rightCube).getOrElse(DoubleCellType))
-      val tileSize = maybeTileSize(leftCube).getOrElse(128)
+      val tileSize = maybeTileSize(leftCube).getOrElse(128*128)
       val newIndex = getPartitionerIndexForMaxPartitionSize[K](nrBands, tileSize, outputCellType.bits)
       SpacePartitioner[K](kb)(implicitly, implicitly, newIndex)
     }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -734,7 +734,7 @@ class OpenEOProcesses extends Serializable {
         val index: PartitionerIndex[K] = getManyBandsIndexGeneric[K]()
         SpacePartitioner[K](kb)(implicitly,implicitly,index)
       } else {
-        val nrBands = leftCount.getOrElse(1) + rightCount.getOrElse(1)
+        val nrBands = leftCount.getOrElse(10) + rightCount.getOrElse(10)
         val outputCellType = maybeCellType(leftCube).getOrElse(DoubleCellType).union(maybeCellType(rightCube).getOrElse(DoubleCellType))
         val tileSize = maybeTileSize(leftCube).getOrElse(128 * 128)
         val newIndex = getPartitionerIndexForMaxPartitionSize[K](nrBands, tileSize, outputCellType.bits)


### PR DESCRIPTION
The default SpacePartitioner uses 16x16 tiles per partition which requires too much memory if there are many bands, dates or if the tiles are large. This commit introduces a partitioner that attempts to control the partition size (max records) based on a maximum memory footprint.

The new partitioner in this special case can have 1,2,4,8,16,32,64,128,256,512, or 1024 records in a single partition based on the dimensions of a single MultiBandTile: tile size, number of bands, and celltype.