### PR TITLE
Make sure requests to hr-vpp-products buckets are sent to the correct endpoint

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
@@ -42,6 +42,8 @@ class MultiClientRangeReaderProvider extends S3RangeReaderProvider {
           s3Client(Region.of("RegionOne"), uri)
         } else if (s3Uri.getBucket.toLowerCase().startsWith("lcfm") || s3Uri.getBucket.toLowerCase().startsWith("eugw")) {
           CreoS3Utils.getCreoS3Client(Region.of("waw3-1"))
+        } else if (s3Uri.getBucket.toLowerCase().startsWith("hr-vpp-products-")) {
+          CreoS3Utils.getCreoS3Client(Region.of("waw3-1"))
         } else s3Client(Region.of("RegionOne"), swiftEndpoint)
       else s3Client(bucketRegion(s3Uri.getBucket))
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -48,14 +48,20 @@ object CreoS3Utils {
   }
 
   def getCreoS3Client(region: Region = cloudFerroRegion): S3Client = {
+    val endpointURI = if (region != cloudFerroRegion) this.getCFEndpoin(region) else URI.create(sys.env("SWIFT_URL"))
     S3Client.builder()
       .credentialsProvider(credentialsProvider)
       .serviceConfiguration(S3Configuration.builder().checksumValidationEnabled(false).build())
       .overrideConfiguration(overrideConfig)
       .forcePathStyle(true)
       .region(region)
-      .endpointOverride(URI.create(sys.env("SWIFT_URL")))
+      .endpointOverride(endpointURI)
       .build()
+  }
+
+  //CloudFerro endpoints follow a structure based on region names.
+  def getCFEndpoin(region: Region): URI = {
+    URI.create(s"https://s3.${region}.cloudferro.com")
   }
 
   private def credentialsProvider = {


### PR DESCRIPTION
This change allows to use different regions than waw3-1 in getCreoS3Client because the endpoint should be constructed depending on the region.

The SWIFT endpoint is only used as fallback if no explicit region is specified (RegionOne is used) 