### PR TITLE
use base resolution when resampling S2 SCL band (gdalwarpoptions) Ope…

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -1503,9 +1503,14 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
 
     def rasterSource(dataPath:String, cloudPath:Option[(String,String)], targetCellType:Option[TargetCellType], targetExtent:ProjectedExtent, sentinelXmlAngleBandIndex: Int): RasterSource = {
       if(dataPath.endsWith(".jp2") || dataPath.contains("NETCDF:")) {
+        var warpOptionsOvr = Some(OverviewStrategy.DEFAULT)
+        if (dataPath.endsWith("SCL_20m.jp2")) {
+          // The overviews in the S2 SCL bands can be wrong, so we need to use the original resolution.
+          warpOptionsOvr = Some(geotrellis.raster.io.geotiff.Base)
+        }
         val alignPixels = !dataPath.contains("NETCDF:") //align target pixels does not yet work with CGLS global netcdfs
         val warpOptions = GDALWarpOptions(alignTargetPixels = alignPixels, cellSize = Some(theResolution), targetCRS = Some(targetExtent.crs), resampleMethod = Some(resampleMethod),
-          te = featureExtentInLayout.map(_.extent), teCRS = Some(targetExtent.crs)
+          te = featureExtentInLayout.map(_.extent), teCRS = Some(targetExtent.crs), ovr = warpOptionsOvr
         )
         if (cloudPath.isDefined) {
           GDALCloudRasterSource(cloudPath.get._1.replace("/vsis3", ""), vsisToHttpsCreo(cloudPath.get._2), GDALPath(dataPath.replace("/vsis3", "")), options = warpOptions, targetCellType = targetCellType)


### PR DESCRIPTION
The overviews in the S2 SCL bands can be wrong, so we need to use the original resolution when resampling instead of the nearest overview (GdalWarpOptions default). This can be done by setting the ovr argument of the GdalWarpOptions to Base.

I tested this locally with Sentinel-2 SCL data that had wrong overview data. It used the correct WarpOptions and gave the correct result for the whole process graph. Creating a unit test for this is harder because `deriveRasterSources` is private, so it would have to be tested at the loadRasterSourceRDD() level. Which requires a mock openSearchClient which returns products that end with "SCL_20m". 

Question: Is this endswith("SCL_20m.jp2") ok, or does it need a regex check for SCL bands. It assumes the SCL bands are always 20m.