### PR TITLE
Dateline 20250327

### DIFF
--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/DataCubeParameters.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/DataCubeParameters.scala
@@ -22,6 +22,7 @@ class DataCubeParameters extends Serializable {
   var pixelBufferY:Double = 0.0
   var noResampleOnRead: Boolean = false
   var useNewFeatureExtentIntersection: Boolean = false
+  var useNewFeatureExtentIntersection2: Boolean = false
   var timeDimensionFilter: Option[Object] = Option.empty
   var allowEmptyCube: Boolean = false
   var loadPerProduct: Boolean = false

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -41,7 +41,8 @@ object ProjectedPolygons {
   private type JList[T] = java.util.List[T]
 
   def apply(pe: ProjectedExtent): ProjectedPolygons = {
-    new ProjectedPolygons(Array(pe.extent.toPolygon()), pe.crs)
+    // Wrap in MultiPolygon for backwards compatibility
+    new ProjectedPolygons(Array(MultiPolygon(pe.extent.toPolygon())), pe.crs)
   }
 
   def apply(geometry: Geometry, crs: CRS): ProjectedPolygons = {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -40,6 +40,14 @@ case class ProjectedPolygons(geometries: Array[Geometry], crs: CRS) {
 object ProjectedPolygons {
   private type JList[T] = java.util.List[T]
 
+  def apply(pe: ProjectedExtent): ProjectedPolygons = {
+    new ProjectedPolygons(Array(pe.extent.toPolygon()), pe.crs)
+  }
+
+  def apply(geometry: Geometry, crs: CRS): ProjectedPolygons = {
+    new ProjectedPolygons(Array(geometry), crs)
+  }
+
   def apply(polygons: Array[MultiPolygon], crs: CRS): ProjectedPolygons = {
     ProjectedPolygons(polygons.toArray[Geometry], crs)
   }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -24,6 +24,15 @@ case class ProjectedPolygons(geometries: Array[Geometry], crs: CRS) {
   }
 
   def polygons: Array[MultiPolygon] = geometries.filter(_.isInstanceOf[MultiPolygon]).map(_.asInstanceOf[MultiPolygon])
+
+  def getFlatMultiPolygon: MultiPolygon = {
+    MultiPolygon(geometries.flatMap {
+      case multiPolygon: MultiPolygon => multiPolygon.polygons
+      case polygon: Polygon => Array(polygon)
+      case _ => Array.empty[Polygon] // ignore non polygon
+    })
+  }
+
   def extent: ProjectedExtent = ProjectedExtent(polygons.toSeq.extent,crs)
   def reproject(crs: CRS): ProjectedPolygons = ProjectedPolygons.reproject(this, crs)
 }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -1420,11 +1420,14 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
          *  - if feature is in utm, target extent may be invalid in feature crs
          *    this is why we take intersection
          */
-        val targetExtentInLatLon = targetExtent.reproject(feature.crs.get)
-        val featureExtentInLatLon = feature.rasterExtent.get.reproject(feature.crs.get, LatLng)
+        val targetExtentInLatLon = targetExtent.reproject(LatLng)
+//        val featureExtentInLatLon = feature.rasterExtent.get.reproject(feature.crs.get, LatLng)
+        val featureExtentInLatLon = safeReproject(ProjectedExtent(feature.rasterExtent.get, feature.crs.get), LatLng).extent
 
         val intersection = featureExtentInLatLon.intersection(targetExtentInLatLon).map(_.buffer(1.0)).getOrElse(featureExtentInLatLon)
-        val tmp = expandToCellSize(intersection.reproject(LatLng, targetExtent.crs), theResolution)
+        val intersectionTargetCRS = safeReproject(ProjectedExtent(intersection, LatLng), targetExtent.crs).extent
+        val intersectionBack = safeReproject(ProjectedExtent(intersection, targetExtent.crs), LatLng).extent
+        val tmp = expandToCellSize(intersectionTargetCRS, theResolution)
         re.createAlignedRasterExtent(tmp)
       } else {
         val featureProjectedExtent = ProjectedExtent(feature.rasterExtent.get, feature.crs.get)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -895,7 +895,7 @@ object FileLayerProvider {
     sc.parallelize(keys.toSeq, 1).map((_, null))
   }
 
-  private def featuresRDD(geometricFeatures: Seq[vector.Feature[Geometry, (RasterSource, Feature)]], metadata: TileLayerMetadata[SpaceTimeKey], targetCRS: CRS, workingPartitioner: SpacePartitioner[SpatialKey], maybeKeys: Option[RDD[(SpatialKey, Iterable[Geometry])]] ,sc: SparkContext) = {
+  private def featuresRDD(geometricFeatures: Seq[vector.Feature[Geometry, (RasterSource, Feature)]], metadata: TileLayerMetadata[SpaceTimeKey], targetCRS: CRS, workingPartitioner: SpacePartitioner[SpatialKey], maybeKeys: Option[RDD[(SpatialKey, Iterable[Geometry])]], sc: SparkContext, datacubeParams: Option[DataCubeParameters]) = {
     val emptyPoint = Point(0.0, 0.0)
     val cubeExtent = metadata.extent
 
@@ -913,8 +913,12 @@ object FileLayerProvider {
         val productCRSOrDefault = eoProductFeature.data._2.crs.getOrElse(targetCRS)
         eoProductFeature.mapGeom(productGeometry => {
           try {
-            val productGeometryProjected = safeReprojectPolygons(ProjectedPolygons(productGeometry, LatLng), productCRSOrDefault)
-            val intersection = productGeometryProjected.getFlatMultiPolygon.intersection(cubeExtent.reprojectAsPolygon(targetCRS, productCRSOrDefault, 0.01))
+            val intersection = if (datacubeParams.getOrElse(new DataCubeParameters).useNewFeatureExtentIntersection2) {
+                val productGeometryProjected = safeReprojectPolygons(ProjectedPolygons(productGeometry, LatLng), productCRSOrDefault)
+                productGeometryProjected.getFlatMultiPolygon.intersection(cubeExtent.reprojectAsPolygon(targetCRS, productCRSOrDefault, 0.01))
+            } else {
+              productGeometry.reproject(LatLng, productCRSOrDefault).intersection(cubeExtent.reprojectAsPolygon(targetCRS, productCRSOrDefault, 0.01))
+            }
             if (intersection.isValid && intersection.getArea > 0.0) {
               intersection.reproject(productCRSOrDefault, targetCRS)
             } else {
@@ -1154,7 +1158,7 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
       } else {
         None
       }
-    val griddedRasterSources: RDD[(SpatialKey, vector.Feature[Geometry, (RasterSource, Feature)])] =  featuresRDD(geometricFeatures, metadata, targetCRS, workingPartitioner,keysIfSparse, sc)
+    val griddedRasterSources: RDD[(SpatialKey, vector.Feature[Geometry, (RasterSource, Feature)])] =  featuresRDD(geometricFeatures, metadata, targetCRS, workingPartitioner,keysIfSparse, sc, datacubeParams)
 
 
     val filteredSources: RDD[(SpatialKey, vector.Feature[Geometry, (RasterSource, Feature)])] = applySpatialMask(datacubeParams, griddedRasterSources,metadata)
@@ -1456,8 +1460,11 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
         val intersectionTargetCrs = intersection match {
           case None =>
             // Item, Asset and Feature mean the same thing in this context.
-            logger.warn(s"Item extent $featureExtentInCommonCRS and target extent $targetExtentInCommonCRS do not intersect. Discarding (${feature.id})")
-            return None // Discard the feature
+            logger.warn(s"Item extent $featureExtentInCommonCRS and target extent $targetExtentInCommonCRS do not intersect. (${feature.id})")
+            // return None // Discard the feature
+            // TODO: feature.rasterExtent is not accurate when going over the antimeridian.
+            // TODO: Fall back to feature.geometry? Now the fallback is to load the whole tile (Just like old intersection code)
+            targetExtent.extent
           case Some(value) => value.reproject(commonCrs, targetExtent.crs)
         }
         var tmp = expandToCellSize(intersectionTargetCrs, theResolution)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.LongAccumulator
 import org.locationtech.jts.geom.Geometry
 import org.openeo.geotrellis.OpenEOProcessScriptBuilder.AnyProcess
 import org.openeo.geotrellis.file.{AbstractPyramidFactory, FixedFeaturesOpenSearchClient}
-import org.openeo.geotrellis.{OpenEOProcessScriptBuilder, healthCheckExtentAssert, healthCheckExtentWarn, isCrsCoveredInHealthCheck, isExtentValidInCrs, safeReproject, sortableSourceName}
+import org.openeo.geotrellis._
 import org.openeo.geotrelliscommon.DatacubeSupport.prepareMask
 import org.openeo.geotrelliscommon.{BatchJobMetadataTracker, ByKeyPartitioner, CloudFilterStrategy, ConfigurableSpatialPartitioner, DataCubeParameters, DatacubeSupport, L1CCloudFilterStrategy, MaskTileLoader, NoCloudFilterStrategy, ResampledTile, SCLConvolutionFilterStrategy, SpaceTimeByMonthPartitioner, SparseSpaceTimePartitioner, autoUtmEpsg}
 import org.openeo.opensearch.OpenSearchClient
@@ -913,7 +913,8 @@ object FileLayerProvider {
         val productCRSOrDefault = eoProductFeature.data._2.crs.getOrElse(targetCRS)
         eoProductFeature.mapGeom(productGeometry => {
           try {
-            val intersection = productGeometry.reproject(LatLng, productCRSOrDefault).intersection(cubeExtent.reprojectAsPolygon(targetCRS, productCRSOrDefault, 0.01))
+            val productGeometryProjected = safeReprojectPolygons(ProjectedPolygons(productGeometry, LatLng), productCRSOrDefault)
+            val intersection = productGeometryProjected.getFlatMultiPolygon.intersection(cubeExtent.reprojectAsPolygon(targetCRS, productCRSOrDefault, 0.01))
             if (intersection.isValid && intersection.getArea > 0.0) {
               intersection.reproject(productCRSOrDefault, targetCRS)
             } else {
@@ -1420,14 +1421,11 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
          *  - if feature is in utm, target extent may be invalid in feature crs
          *    this is why we take intersection
          */
-        val targetExtentInLatLon = targetExtent.reproject(LatLng)
-//        val featureExtentInLatLon = feature.rasterExtent.get.reproject(feature.crs.get, LatLng)
-        val featureExtentInLatLon = safeReproject(ProjectedExtent(feature.rasterExtent.get, feature.crs.get), LatLng).extent
+        val targetExtentInLatLon = targetExtent.reproject(feature.crs.get)
+        val featureExtentInLatLon = feature.rasterExtent.get.reproject(feature.crs.get, LatLng)
 
         val intersection = featureExtentInLatLon.intersection(targetExtentInLatLon).map(_.buffer(1.0)).getOrElse(featureExtentInLatLon)
-        val intersectionTargetCRS = safeReproject(ProjectedExtent(intersection, LatLng), targetExtent.crs).extent
-        val intersectionBack = safeReproject(ProjectedExtent(intersection, targetExtent.crs), LatLng).extent
-        val tmp = expandToCellSize(intersectionTargetCRS, theResolution)
+        val tmp = expandToCellSize(intersection.reproject(LatLng, targetExtent.crs), theResolution)
         re.createAlignedRasterExtent(tmp)
       } else {
         val featureProjectedExtent = ProjectedExtent(feature.rasterExtent.get, feature.crs.get)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -20,7 +20,8 @@ import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 
 import java.lang
 import java.net.{SocketException, SocketTimeoutException, URI}
-import java.nio.file.{Path, Paths}
+import java.nio.charset.Charset
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant}
 import java.util.concurrent.ConcurrentHashMap
@@ -382,20 +383,33 @@ package object geotrellis {
       }
   }
 
-  def safeReprojectPolygons(inputProjectedExtent: ProjectedPolygons, targetCrs: CRS): ProjectedPolygons = {
-    if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
-    lazy val transform = SafeTransform(inputProjectedExtent.crs, targetCrs)
-    ProjectedPolygons(inputProjectedExtent.polygons.map(_.reproject(transform)), targetCrs)
+  def polygonWrapAntimeridian(polygon: Polygon): Polygon = {
+    // TODO: Split polygon across antimeridian instead?
+    val polygonCopy = polygon.copy().asInstanceOf[Polygon]
+    if (polygon.extent.width > 180 && polygon.extent.width < 360) {
+      // Documentation says CoordinateSequenceFilter should be used, but that has a complex interface
+      polygonCopy.getCoordinates.foreach(c => c.x = to_0_360_range(c.x))
+    }
+    polygonCopy
   }
 
-
-
-  //  // Check if it is safe to reproject and back:
-  //  val polygon = new ProjectedPolygons(Array(extent.extent.toPolygon()), extent.crs)
-  //  val polygonProjected = safeReprojectPolygons(polygon, targetCrs)
-  //  val polygonProjectedBack = safeReprojectPolygons(polygonProjected, extent.crs)
-  //  projectedPolygonsEquals(polygonProjectedBack, polygon)
-
+  def safeReprojectPolygons(inputProjectedPolygons: ProjectedPolygons, targetCrs: CRS)(implicit logger: Logger): ProjectedPolygons = {
+    if (inputProjectedPolygons.crs == targetCrs) return inputProjectedPolygons
+    lazy val transform = SafeTransform(inputProjectedPolygons.crs, targetCrs)
+    var geometries = inputProjectedPolygons.geometries.map(_.reproject(transform))
+    if (targetCrs == LatLng) {
+      geometries = geometries.map {
+        case polygon: Polygon => polygonWrapAntimeridian(polygon)
+        case multiPolygon: MultiPolygon =>
+          MultiPolygon(multiPolygon.polygons.map(polygonWrapAntimeridian))
+        case geometry: Geometry =>
+          // Disable log before merging
+          logger.info("Was only expecting (Multi)Polygon, but got: " + geometry)
+          geometry
+      }
+    }
+    ProjectedPolygons(geometries, targetCrs)
+  }
 
   def projectedPolygonsEquals(p1: ProjectedPolygons, p2: ProjectedPolygons): Boolean = {
     if (p1.crs != p2.crs) return false
@@ -405,7 +419,7 @@ package object geotrellis {
       .forall(identity)
   }
 
-  def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS): ProjectedExtent = {
+  def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS)(implicit logger: Logger): ProjectedExtent = {
     if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
 //     val reprojectedPolygon = inputProjectedExtent.extent.reprojectAsPolygon(inputProjectedExtent.crs, targetCrs, 0.01)
     val polygons = ProjectedPolygons(Array(inputProjectedExtent.extent.toPolygon()), "EPSG:" + inputProjectedExtent.crs.epsgCode.get)
@@ -428,8 +442,47 @@ package object geotrellis {
         }
       }
     }
-    ProjectedExtent(reprojected, targetCrs)
+    val projectedExtent = ProjectedExtent(reprojected, targetCrs)
+    // dumpGeoJson(toGeoJsonDebug(projectedExtent), Some("projectedExtent_" + projectedExtent))
+    projectedExtent
   }
+
+  def toGeoJsonDebug(polygons: ProjectedPolygons): String = {
+    if (polygons.geometries.length != 1) {
+      throw new IllegalArgumentException("Only one geometry is supported at the moment.")
+    }
+    val str = polygons.getFlatMultiPolygon.toGeoJson()
+    var j = SimpleJson.parse(str)
+    val crs = polygons.crs.proj4jCrs.getName
+    j = j + ("crs" -> Map("type" -> "name", "properties" -> Map("name" -> crs)))
+    SimpleJson.serialize(j)
+  }
+
+  def toGeoJsonDebug(geometry: Geometry): String = {
+    val pp = ProjectedPolygons(Array(geometry), LatLng)
+    toGeoJsonDebug(pp)
+  }
+
+  def toGeoJsonDebug(inputProjectedExtent: ProjectedExtent): String = {
+    val pp = ProjectedPolygons(Array(inputProjectedExtent.extent.toPolygon()), "EPSG:" + inputProjectedExtent.crs.epsgCode.get)
+    toGeoJsonDebug(pp)
+  }
+
+  def toGeoJsonDebug(extent: Extent): String = {
+    val pe = ProjectedExtent(extent, LatLng)
+    toGeoJsonDebug(pe)
+  }
+
+  def dumpGeoJson(str: String, name: Option[String] = None): Unit = {
+    //    val str = toGeoJsonDebug(polygons)
+    var path = "tmp/" + name.getOrElse("dumpGeoJson")
+    if (!path.endsWith("json")) {
+      path = path + ".geojson"
+    }
+
+    Files.write(Paths.get(path), str.getBytes(Charset.forName("UTF-8")), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+  }
+
 
   /**
    * DANGER. Might crash system if no memory limit is specified.

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -1,6 +1,6 @@
 package org.openeo
 
-import _root_.geotrellis.proj4.{CRS, LatLng, WebMercator}
+import _root_.geotrellis.proj4.{CRS, LatLng, Sinusoidal, WebMercator}
 import _root_.geotrellis.raster._
 import _root_.geotrellis.vector._
 import net.jodah.failsafe.event.{ExecutionAttemptedEvent, ExecutionCompletedEvent}
@@ -316,10 +316,10 @@ package object geotrellis {
     None
   }
 
-  def isExtentValidInCrs(extent: ProjectedExtent, targetCrs: CRS): Boolean = {
+  def isExtentValidInCrs(extent: ProjectedExtent, targetCrs: CRS)(implicit logger: Logger): Boolean = {
     if (extent.crs == targetCrs) return true
-    if (targetCrs == CRS.fromEpsgCode(4326)) {
-      // LatLon covers the whole world, so it's always valid
+    if (targetCrs == CRS.fromEpsgCode(4326) || targetCrs == Sinusoidal) {
+      // LatLon and Sinusoidal cover the whole world, so it's always valid
       // Function would work fine without this check too.
       return true
     }
@@ -333,7 +333,10 @@ package object geotrellis {
       if (!healthCheckExtent(reprojectedBack)) return false
       reprojectedBack.extent.intersects(extent.extent) // Easy check for unknown CRSes
     } catch {
-      case _: Throwable => false
+      case e: Throwable =>
+        logger.warn(s"Error while checking if extent is valid in CRS: $targetCrs. " +
+          s"Extent: $extent. Error: ${e.getMessage}")
+        false
     }
   }
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -344,9 +344,71 @@ package object geotrellis {
     (x + 360 * 10) % 360
   }
 
+  /**
+   * Will give actual angle, but in the LatLng extent.
+   */
+  private def to_min180_180_range(x: Double): Double = {
+    val n = (x + 360 * 10) % 360
+    if (n > 180) n - 360 else n
+  }
+
+  import _root_.geotrellis.proj4._
+
+  object SafeTransform {
+    def apply(src: CRS, dest: CRS): (Double, Double) => (Double, Double) =
+      src.alternateTransform(dest) match {
+        case Some(f) => f
+        case None => SafeProj4Transform(src, dest)
+      }
+  }
+
+  object SafeProj4Transform {
+    def apply(src: CRS, dest: CRS): Transform =
+      if (src == dest) {
+        (x: Double, y: Double) => (x, y)
+      } else {
+        val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
+
+        { (x: Double, y: Double) =>
+          val xNew = if (src == LatLng) to_min180_180_range(x) else x
+          val srcP = new ProjCoordinate(xNew, y)
+          val destP = new ProjCoordinate
+          t.transform(srcP, destP)
+          (destP.x, destP.y)
+        }
+      }
+  }
+
+  def safeReprojectPolygons(inputProjectedExtent: ProjectedPolygons, targetCrs: CRS): ProjectedPolygons = {
+    if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
+    lazy val transform = SafeTransform(inputProjectedExtent.crs, targetCrs)
+    ProjectedPolygons(inputProjectedExtent.polygons.map(_.reproject(transform)), targetCrs)
+  }
+
+
+
+  //  // Check if it is safe to reproject and back:
+  //  val polygon = new ProjectedPolygons(Array(extent.extent.toPolygon()), extent.crs)
+  //  val polygonProjected = safeReprojectPolygons(polygon, targetCrs)
+  //  val polygonProjectedBack = safeReprojectPolygons(polygonProjected, extent.crs)
+  //  projectedPolygonsEquals(polygonProjectedBack, polygon)
+
+
+  def projectedPolygonsEquals(p1: ProjectedPolygons, p2: ProjectedPolygons): Boolean = {
+    if (p1.crs != p2.crs) return false
+    if (p1.polygons.length != p2.polygons.length) return false
+    p1.polygons.zip(p2.polygons)
+      .map { case (a, b) => a.equalsExact(b, 0.001) }
+      .forall(identity)
+  }
+
   def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS): ProjectedExtent = {
     if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
-    var reprojected = inputProjectedExtent.extent.reproject(inputProjectedExtent.crs, targetCrs)
+//     val reprojectedPolygon = inputProjectedExtent.extent.reprojectAsPolygon(inputProjectedExtent.crs, targetCrs, 0.01)
+    val polygons = ProjectedPolygons(Array(inputProjectedExtent.extent.toPolygon()), "EPSG:" + inputProjectedExtent.crs.epsgCode.get)
+    val reprojectedPolygon = safeReprojectPolygons(polygons, targetCrs)
+    val envelope = reprojectedPolygon.polygons(0).getEnvelopeInternal
+    var reprojected = Extent(envelope.getMinX, envelope.getMinY, envelope.getMaxX, envelope.getMaxY)
     // TODO: Needed for webmercator too?
     if (targetCrs == LatLng && reprojected.width > 180 && reprojected.width < 360) {
       // Fix width wrap when projecting over anti meridian in LatLon.

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -1,6 +1,5 @@
 package org.openeo
 
-import _root_.geotrellis.proj4.{CRS, LatLng, Sinusoidal, WebMercator}
 import _root_.geotrellis.proj4._
 import _root_.geotrellis.raster._
 import _root_.geotrellis.vector._
@@ -336,8 +335,9 @@ package object geotrellis {
       reprojectedBack.extent.intersects(extent.extent) // Easy check for unknown CRSes
     } catch {
       case e: Throwable =>
-        logger.warn(s"Error while checking if extent is valid in CRS: $targetCrs. " +
-          s"Extent: $extent. Error: ${e.getMessage}")
+        // TODO: Might give too mush logs, so keep disabled
+        // logger.warn(s"Error while checking if extent is valid in CRS: $targetCrs. " +
+        //   s"Extent: $extent. Error: ${e.getMessage}")
         false
     }
   }
@@ -358,27 +358,27 @@ package object geotrellis {
   }
 
   object SafeTransform {
+    object SafeProj4Transform {
+      def apply(src: CRS, dest: CRS): Transform =
+        if (src == dest) {
+          (x: Double, y: Double) => (x, y)
+        } else {
+          val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
+
+          { (x: Double, y: Double) =>
+            val xNew = if (src == LatLng) to_min180_180_range(x) else x
+            val srcP = new ProjCoordinate(xNew, y)
+            val destP = new ProjCoordinate
+            t.transform(srcP, destP)
+            (destP.x, destP.y)
+          }
+        }
+    }
+
     def apply(src: CRS, dest: CRS): (Double, Double) => (Double, Double) =
       src.alternateTransform(dest) match {
         case Some(f) => f
         case None => SafeProj4Transform(src, dest)
-      }
-  }
-
-  object SafeProj4Transform {
-    def apply(src: CRS, dest: CRS): Transform =
-      if (src == dest) {
-        (x: Double, y: Double) => (x, y)
-      } else {
-        val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
-
-        { (x: Double, y: Double) =>
-          val xNew = if (src == LatLng) to_min180_180_range(x) else x
-          val srcP = new ProjCoordinate(xNew, y)
-          val destP = new ProjCoordinate
-          t.transform(srcP, destP)
-          (destP.x, destP.y)
-        }
       }
   }
 

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -422,18 +422,18 @@ package object geotrellis {
     pp
   }
 
-  def projectedPolygonsEquals(p1: ProjectedPolygons, p2: ProjectedPolygons): Boolean = {
+  def projectedPolygonsEquals(p1: ProjectedPolygons, p2: ProjectedPolygons, tolerance: Double = 0.001): Boolean = {
     if (p1.crs != p2.crs) return false
     if (p1.polygons.length != p2.polygons.length) return false
     p1.polygons.zip(p2.polygons)
-      .map { case (a, b) => a.equalsExact(b, 0.001) }
+      .map { case (a, b) => a.equalsExact(b, tolerance) }
       .forall(identity)
   }
 
   def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS)(implicit logger: Logger): ProjectedExtent = {
     if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
     val transform = SafeTransform(inputProjectedExtent.crs, targetCrs)
-    val reprojectedPolygon = reprojectExtentAsPolygon(inputProjectedExtent.extent, transform, 0.01) // TODO: Adapt relError to CRS
+    val reprojectedPolygon = reprojectExtentAsPolygon(inputProjectedExtent.extent, transform, 0.001) // TODO: Adapt relError to CRS
     val envelope = reprojectedPolygon.getEnvelopeInternal
     var reprojected = Extent(envelope.getMinX, envelope.getMinY, envelope.getMaxX, envelope.getMaxY)
     val inputIsUTM = inputProjectedExtent.crs.proj4jCrs.getProjection.getName == "utm"
@@ -463,6 +463,7 @@ package object geotrellis {
     val str = polygons.getFlatMultiPolygon.toGeoJson()
     var j = SimpleJson.parse(str)
     val crs = polygons.crs.proj4jCrs.getName
+    // GeoJson officially only supports LatLng, but qgis works with custom CRSes too:
     j = j + ("crs" -> Map("type" -> "name", "properties" -> Map("name" -> crs)))
     SimpleJson.serialize(j)
   }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -1,6 +1,7 @@
 package org.openeo
 
 import _root_.geotrellis.proj4.{CRS, LatLng, Sinusoidal, WebMercator}
+import _root_.geotrellis.proj4._
 import _root_.geotrellis.raster._
 import _root_.geotrellis.vector._
 import net.jodah.failsafe.event.{ExecutionAttemptedEvent, ExecutionCompletedEvent}
@@ -356,8 +357,6 @@ package object geotrellis {
     if (n > 180) n - 360 else n
   }
 
-  import _root_.geotrellis.proj4._
-
   object SafeTransform {
     def apply(src: CRS, dest: CRS): (Double, Double) => (Double, Double) =
       src.alternateTransform(dest) match {
@@ -422,9 +421,9 @@ package object geotrellis {
   def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS)(implicit logger: Logger): ProjectedExtent = {
     if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
 //     val reprojectedPolygon = inputProjectedExtent.extent.reprojectAsPolygon(inputProjectedExtent.crs, targetCrs, 0.01)
-    val polygons = ProjectedPolygons(Array(inputProjectedExtent.extent.toPolygon()), "EPSG:" + inputProjectedExtent.crs.epsgCode.get)
+    val polygons = ProjectedPolygons(inputProjectedExtent)
     val reprojectedPolygon = safeReprojectPolygons(polygons, targetCrs)
-    val envelope = reprojectedPolygon.polygons(0).getEnvelopeInternal
+    val envelope = reprojectedPolygon.getFlatMultiPolygon.getEnvelopeInternal
     var reprojected = Extent(envelope.getMinX, envelope.getMinY, envelope.getMaxX, envelope.getMaxY)
     // TODO: Needed for webmercator too?
     if (targetCrs == LatLng && reprojected.width > 180 && reprojected.width < 360) {
@@ -442,9 +441,7 @@ package object geotrellis {
         }
       }
     }
-    val projectedExtent = ProjectedExtent(reprojected, targetCrs)
-    // dumpGeoJson(toGeoJsonDebug(projectedExtent), Some("projectedExtent_" + projectedExtent))
-    projectedExtent
+    ProjectedExtent(reprojected, targetCrs)
   }
 
   def toGeoJsonDebug(polygons: ProjectedPolygons): String = {
@@ -459,18 +456,15 @@ package object geotrellis {
   }
 
   def toGeoJsonDebug(geometry: Geometry): String = {
-    val pp = ProjectedPolygons(Array(geometry), LatLng)
-    toGeoJsonDebug(pp)
+    toGeoJsonDebug(ProjectedPolygons(Array(geometry), LatLng))
   }
 
   def toGeoJsonDebug(inputProjectedExtent: ProjectedExtent): String = {
-    val pp = ProjectedPolygons(Array(inputProjectedExtent.extent.toPolygon()), "EPSG:" + inputProjectedExtent.crs.epsgCode.get)
-    toGeoJsonDebug(pp)
+    toGeoJsonDebug(ProjectedPolygons(inputProjectedExtent))
   }
 
   def toGeoJsonDebug(extent: Extent): String = {
-    val pe = ProjectedExtent(extent, LatLng)
-    toGeoJsonDebug(pe)
+    toGeoJsonDebug(ProjectedExtent(extent, LatLng))
   }
 
   def dumpGeoJson(str: String, name: Option[String] = None): Unit = {
@@ -482,7 +476,6 @@ package object geotrellis {
 
     Files.write(Paths.get(path), str.getBytes(Charset.forName("UTF-8")), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
   }
-
 
   /**
    * DANGER. Might crash system if no memory limit is specified.

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -3,6 +3,7 @@ package org.openeo
 import _root_.geotrellis.proj4._
 import _root_.geotrellis.raster._
 import _root_.geotrellis.vector._
+import _root_.geotrellis.vector.reproject.Reproject._
 import net.jodah.failsafe.event.{ExecutionAttemptedEvent, ExecutionCompletedEvent}
 import net.jodah.failsafe.{ExecutionContext, Failsafe, RetryPolicy => FailsafeRetryPolicy}
 import org.apache.spark.SparkContext
@@ -26,6 +27,7 @@ import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant}
 import java.util.concurrent.ConcurrentHashMap
 import scala.compat.java8.FunctionConverters._
+import scala.reflect.io.Directory
 
 
 package object geotrellis {
@@ -392,22 +394,32 @@ package object geotrellis {
     polygonCopy
   }
 
+  private def projectedPolygonWrapAntimeridian(inputProjectedPolygons: ProjectedPolygons): ProjectedPolygons = {
+    if (inputProjectedPolygons.crs != LatLng) throw new IllegalArgumentException("Only LatLng CRS is supported for wrapping")
+    val geometries = inputProjectedPolygons.geometries.map {
+      case polygon: Polygon => polygonWrapAntimeridian(polygon)
+      case multiPolygon: MultiPolygon =>
+        MultiPolygon(multiPolygon.polygons.map(polygonWrapAntimeridian))
+      case geometry: Geometry =>
+        // logger.info("Was only expecting (Multi)Polygon, but got: " + geometry)
+        geometry
+    }
+    ProjectedPolygons(geometries, inputProjectedPolygons.crs)
+  }
+
   def safeReprojectPolygons(inputProjectedPolygons: ProjectedPolygons, targetCrs: CRS)(implicit logger: Logger): ProjectedPolygons = {
     if (inputProjectedPolygons.crs == targetCrs) return inputProjectedPolygons
+    // TODO, this should refine the polygon till a maximum error. Just like refine here:
+    // https://github.com/pomadchin/geotrellis/blob/b071b33/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala#L94
     lazy val transform = SafeTransform(inputProjectedPolygons.crs, targetCrs)
-    var geometries = inputProjectedPolygons.geometries.map(_.reproject(transform))
-    if (targetCrs == LatLng) {
-      geometries = geometries.map {
-        case polygon: Polygon => polygonWrapAntimeridian(polygon)
-        case multiPolygon: MultiPolygon =>
-          MultiPolygon(multiPolygon.polygons.map(polygonWrapAntimeridian))
-        case geometry: Geometry =>
-          // Disable log before merging
-          logger.info("Was only expecting (Multi)Polygon, but got: " + geometry)
-          geometry
-      }
+    val geometries = inputProjectedPolygons.geometries.map(_.reproject(transform))
+    var pp = ProjectedPolygons(geometries, targetCrs)
+    val inputIsUTM = inputProjectedPolygons.crs.proj4jCrs.getProjection.getName == "utm"
+    if (inputIsUTM && targetCrs == LatLng) {
+      // When the extent was utm, some wrapping may have occurred
+      pp = projectedPolygonWrapAntimeridian(pp)
     }
-    ProjectedPolygons(geometries, targetCrs)
+    pp
   }
 
   def projectedPolygonsEquals(p1: ProjectedPolygons, p2: ProjectedPolygons): Boolean = {
@@ -420,13 +432,13 @@ package object geotrellis {
 
   def safeReproject(inputProjectedExtent: ProjectedExtent, targetCrs: CRS)(implicit logger: Logger): ProjectedExtent = {
     if (inputProjectedExtent.crs == targetCrs) return inputProjectedExtent
-//     val reprojectedPolygon = inputProjectedExtent.extent.reprojectAsPolygon(inputProjectedExtent.crs, targetCrs, 0.01)
-    val polygons = ProjectedPolygons(inputProjectedExtent)
-    val reprojectedPolygon = safeReprojectPolygons(polygons, targetCrs)
-    val envelope = reprojectedPolygon.getFlatMultiPolygon.getEnvelopeInternal
+    val transform = SafeTransform(inputProjectedExtent.crs, targetCrs)
+    val reprojectedPolygon = reprojectExtentAsPolygon(inputProjectedExtent.extent, transform, 0.01) // TODO: Adapt relError to CRS
+    val envelope = reprojectedPolygon.getEnvelopeInternal
     var reprojected = Extent(envelope.getMinX, envelope.getMinY, envelope.getMaxX, envelope.getMaxY)
-    // TODO: Needed for webmercator too?
-    if (targetCrs == LatLng && reprojected.width > 180 && reprojected.width < 360) {
+    val inputIsUTM = inputProjectedExtent.crs.proj4jCrs.getProjection.getName == "utm"
+    // utm for sure does not cover the world width. TODO: Also swap when coming from WebMercator or some other niche projections
+    if (targetCrs == LatLng && inputIsUTM && reprojected.width > 180 && reprojected.width < 360) {
       // Fix width wrap when projecting over anti meridian in LatLon.
       // Reprojecting an extent could make the left and the right side swap differently over the antimeridian.
       // A single point will always work, so consider that as the source of truth
@@ -468,7 +480,8 @@ package object geotrellis {
   }
 
   def dumpGeoJson(str: String, name: Option[String] = None): Unit = {
-    //    val str = toGeoJsonDebug(polygons)
+    val outDir = Paths.get("tmp/")
+    Files.createDirectories(outDir)
     var path = "tmp/" + name.getOrElse("dumpGeoJson")
     if (!path.endsWith("json")) {
       path = path + ".geojson"

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
@@ -176,16 +176,17 @@ class PackageTest {
     val polygonLatLng = ProjectedPolygons(polygon, LatLng)
     val polygonUtm = safeReprojectPolygons(polygonLatLng, CRS.fromName("EPSG:32660"))
     val polygonBack = safeReprojectPolygons(polygonUtm, LatLng)
-//    assertTrue(projectedPolygonsEquals(polygonBack, polygonLatLng))
+    assertTrue(projectedPolygonsEquals(polygonBack, polygonLatLng))
 
     val polygonExtent = ProjectedExtent(e, LatLng)
     val polygonExtentUtm = safeReproject(polygonExtent, CRS.fromName("EPSG:32660"))
     val polygonExtentBack = safeReproject(polygonExtentUtm, LatLng)
+    assertTrue(polygonExtent.extent.equalsExact(polygonExtentBack.extent, 2)) // reprojecting extent is inaccurate
     print(polygonExtentBack)
   }
 
   @Test
-  def testSafeReproject(): Unit = {
+  def testSafesafeReprojectPolygons(): Unit = {
     val products = ProjectedPolygons.fromVectorFile(getClass.getResource("/org/openeo/geotrellis/testAntimerideanArtifacts.json").getPath)
     val productsLatLng = safeReprojectPolygons(products, LatLng)
     val productsLatLngMp = productsLatLng.getFlatMultiPolygon

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
@@ -173,7 +173,7 @@ class PackageTest {
   def testAntimeridianWrap(): Unit = {
     val e = Extent(178, 20, 180.1, 21)
     val polygon = e.toPolygon()
-    val polygonLatLng = ProjectedPolygons(Array(MultiPolygon(polygon)), LatLng)
+    val polygonLatLng = ProjectedPolygons(polygon, LatLng)
     val polygonUtm = safeReprojectPolygons(polygonLatLng, CRS.fromName("EPSG:32660"))
     val polygonBack = safeReprojectPolygons(polygonUtm, LatLng)
 //    assertTrue(projectedPolygonsEquals(polygonBack, polygonLatLng))
@@ -193,7 +193,7 @@ class PackageTest {
 
     val targetExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
     dumpGeoJson(toGeoJsonDebug(targetExtent), Some("targetExtent"))
-    val targetExtentPolygon = ProjectedPolygons(Array(MultiPolygon(targetExtent.extent.toPolygon())), targetExtent.crs)
+    val targetExtentPolygon = ProjectedPolygons(targetExtent)
     val targetExtentLatLng = safeReprojectPolygons(targetExtentPolygon, LatLng)
     val targetExtentLatLngMp = targetExtentLatLng.getFlatMultiPolygon
     dumpGeoJson(toGeoJsonDebug(targetExtentLatLngMp), Some("targetExtentLatLngMp"))

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
@@ -1,20 +1,19 @@
 package org.openeo.geotrellis
 
-import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.proj4.{CRS, LatLng, Sinusoidal, WebMercator}
+import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.raster.{ByteCellType, ByteUserDefinedNoDataCellType, FloatUserDefinedNoDataCellType, UByteCellType, UByteUserDefinedNoDataCellType}
-import org.openeo.geotrellis.geotiff._
-
-import java.nio.file.{Files, Path}
-import geotrellis.vector.{Extent, MultiPolygon, Point, Polygon, ProjectedExtent, ReprojectGeometry}
+import geotrellis.vector._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
-import org.locationtech.proj4j.{BasicCoordinateTransform, ProjCoordinate}
+import org.openeo.geotrellis.geotiff._
 import org.openeo.geotrellis.layers.FileLayerProvider
 import org.slf4j.{Logger, LoggerFactory}
+
+import java.nio.file.{Files, Path}
 
 object PackageTest {
   private implicit val logger: Logger = LoggerFactory.getLogger(classOf[FileLayerProvider])
@@ -183,5 +182,24 @@ class PackageTest {
     val polygonExtentUtm = safeReproject(polygonExtent, CRS.fromName("EPSG:32660"))
     val polygonExtentBack = safeReproject(polygonExtentUtm, LatLng)
     print(polygonExtentBack)
+  }
+
+  @Test
+  def testSafeReproject(): Unit = {
+    val products = ProjectedPolygons.fromVectorFile(getClass.getResource("/org/openeo/geotrellis/testAntimerideanArtifacts.json").getPath)
+    val productsLatLng = safeReprojectPolygons(products, LatLng)
+    val productsLatLngMp = productsLatLng.getFlatMultiPolygon
+    dumpGeoJson(toGeoJsonDebug(productsLatLngMp), Some("productsLatLngMp"))
+
+    val targetExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
+    dumpGeoJson(toGeoJsonDebug(targetExtent), Some("targetExtent"))
+    val targetExtentPolygon = ProjectedPolygons(Array(MultiPolygon(targetExtent.extent.toPolygon())), targetExtent.crs)
+    val targetExtentLatLng = safeReprojectPolygons(targetExtentPolygon, LatLng)
+    val targetExtentLatLngMp = targetExtentLatLng.getFlatMultiPolygon
+    dumpGeoJson(toGeoJsonDebug(targetExtentLatLngMp), Some("targetExtentLatLngMp"))
+
+    val intersection = productsLatLngMp.intersection(targetExtentLatLngMp)
+    dumpGeoJson(toGeoJsonDebug(intersection), Some("intersection"))
+    assertTrue(intersection.getArea > 0)
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/PackageTest.scala
@@ -6,12 +6,13 @@ import geotrellis.raster.{ByteCellType, ByteUserDefinedNoDataCellType, FloatUser
 import org.openeo.geotrellis.geotiff._
 
 import java.nio.file.{Files, Path}
-import geotrellis.vector.{Extent, ProjectedExtent}
+import geotrellis.vector.{Extent, MultiPolygon, Point, Polygon, ProjectedExtent, ReprojectGeometry}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+import org.locationtech.proj4j.{BasicCoordinateTransform, ProjCoordinate}
 import org.openeo.geotrellis.layers.FileLayerProvider
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -165,5 +166,22 @@ class PackageTest {
   def testTolerance(): Unit = {
     val pe = ProjectedExtent(Extent(2580000.0, 1360000.0, 7350000.0, 5445000.0), CRS.fromName("EPSG:3035"))
     healthCheckExtentAssert(pe, "Extent should be considered valid: ")
+  }
+
+
+
+  @Test
+  def testAntimeridianWrap(): Unit = {
+    val e = Extent(178, 20, 180.1, 21)
+    val polygon = e.toPolygon()
+    val polygonLatLng = ProjectedPolygons(Array(MultiPolygon(polygon)), LatLng)
+    val polygonUtm = safeReprojectPolygons(polygonLatLng, CRS.fromName("EPSG:32660"))
+    val polygonBack = safeReprojectPolygons(polygonUtm, LatLng)
+//    assertTrue(projectedPolygonsEquals(polygonBack, polygonLatLng))
+
+    val polygonExtent = ProjectedExtent(e, LatLng)
+    val polygonExtentUtm = safeReproject(polygonExtent, CRS.fromName("EPSG:32660"))
+    val polygonExtentBack = safeReproject(polygonExtentUtm, LatLng)
+    print(polygonExtentBack)
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1217,9 +1217,9 @@ class FileLayerProviderTest extends RasterMatchers{
   @ValueSource(strings = Array("EPSG:32601", "EPSG:32660", "EPSG:4326", "EPSG:3857"))
   def testMissingS2DateLine(crsName: String): Unit = {
     // typically requires PROJ_LIB to be set
-    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
-      return
-    }
+//    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
+//      return
+//    }
     val outDir = Paths.get("tmp/FileLayerProviderTest_" + crsName.replace(":", "_") + "/")
     new Directory(outDir.toFile).deepFiles.foreach(_.delete())
     Files.createDirectories(outDir)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -29,7 +29,7 @@ import org.openeo.geotrellis.file.{FixedFeaturesOpenSearchClient, PyramidFactory
 import org.openeo.geotrellis.geotiff._
 import org.openeo.geotrellis.layers.FileLayerProvider.rasterSourceRDD
 import org.openeo.geotrellis.netcdf.{NetCDFOptions, NetCDFRDDWriter}
-import org.openeo.geotrellis.{LayerFixtures, ProjectedPolygons}
+import org.openeo.geotrellis._
 import org.openeo.geotrelliscommon.DatacubeSupport._
 import org.openeo.geotrelliscommon.{ConfigurableSpaceTimePartitioner, DataCubeParameters, DatacubeSupport, NoCloudFilterStrategy, SpaceTimeByMonthPartitioner, SparseSpaceTimePartitioner}
 import org.openeo.opensearch.OpenSearchResponses.{CreoFeatureCollection, FeatureCollection, Link}
@@ -1217,9 +1217,9 @@ class FileLayerProviderTest extends RasterMatchers{
   @ValueSource(strings = Array("EPSG:32601", "EPSG:32660", "EPSG:4326", "EPSG:3857"))
   def testMissingS2DateLine(crsName: String): Unit = {
     // typically requires PROJ_LIB to be set
-//    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
-//      return
-//    }
+    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
+      return
+    }
     val outDir = Paths.get("tmp/FileLayerProviderTest_" + crsName.replace(":", "_") + "/")
     new Directory(outDir.toFile).deepFiles.foreach(_.delete())
     Files.createDirectories(outDir)
@@ -1301,7 +1301,7 @@ class FileLayerProviderTest extends RasterMatchers{
   @Test
   def testAntimerideanArtifacts(): Unit = {
     val projectedExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
-    val poly2 = ProjectedPolygons(Array(MultiPolygon(projectedExtent.extent.toPolygon())), projectedExtent.crs)
+    val poly2 = ProjectedPolygons(projectedExtent)
 
     val layer = LayerFixtures.creodiasCube(
       LocalDate.of(2020, 8, 1),

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1213,28 +1213,26 @@ class FileLayerProviderTest extends RasterMatchers{
     assertEquals(8, band.get(200, 200))
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("EPSG:32601", "EPSG:32660", "EPSG:4326", "EPSG:3857"))
-  def testMissingS2DateLine(crsName: String): Unit = {
-    // typically requires PROJ_LIB to be set
-    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
-      return
-    }
-    val outDir = Paths.get("tmp/FileLayerProviderTest_" + crsName.replace(":", "_") + "/")
+
+  /**
+   * Writes a tiff files and check if it contains expected pixels
+   */
+  private def testMissingS2DateLineInternal(extent: Extent,
+                                            specificCrs: CRS,
+                                            name: String,
+                                           ): Unit = {
+    val uniqueName = name + "_" + specificCrs.toString.replace(":", "_")
+    val outDir = Paths.get("tmp/FileLayerProviderTest_" + uniqueName + "/")
     new Directory(outDir.toFile).deepFiles.foreach(_.delete())
     Files.createDirectories(outDir)
 
-    val extent = Extent(178.1, 70.3, 178.9, 70.9)
     val projected_polygons_native_crs = ProjectedPolygons.fromExtent(extent, LatLng.proj4jCrs.toString)
-    val specificCrs = CRS.fromName(crsName)
     val reprojected = projected_polygons_native_crs.polygons.head.reproject(projected_polygons_native_crs.crs, specificCrs)
     val poly2 = ProjectedPolygons(Array(reprojected), specificCrs)
 
-    if (crsName == "EPSG:4326") {
-      val poly2GeoJson = poly2.polygons.head.toGeoJson
-      // geojson only officially suports latLon
-      Files.writeString(Paths.get(outDir + "/polygons.geojson"), poly2GeoJson)
-    }
+    val poly2GeoJson = toGeoJsonDebug(poly2)
+    // geojson only officially supports latLon, but QGIS handles custom CRSes
+    Files.writeString(Paths.get(outDir + "/" + uniqueName + ".geojson"), poly2GeoJson)
 
     val layer = LayerFixtures.sentinel2Cube(
       LocalDate.of(2024, 4, 2),
@@ -1259,7 +1257,23 @@ class FileLayerProviderTest extends RasterMatchers{
     }
     assertTrue(found10)
     val cubeSpatial = layer.toSpatial()
-    cubeSpatial.writeGeoTiff(outDir + "/testMissingS2DateLine_" + crsName.replace(":", "_") + ".tiff")
+    cubeSpatial.writeGeoTiff(outDir + "/" + uniqueName + ".tiff")
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("EPSG:32601", "EPSG:32660", "EPSG:4326", "EPSG:3857"))
+  def testMissingS2DateLine(crsName: String): Unit = {
+    // typically requires PROJ_LIB to be set
+    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
+      return
+    }
+
+    for (tup <- Seq(
+      (Extent(178.1, 70.3, 178.9, 70.9), "left"),
+      (Extent(-179.9, 70.1, -179.2, 71.3), "right"),
+    )) {
+      testMissingS2DateLineInternal(tup._1, CRS.fromName(crsName), tup._2)
+    }
   }
 
   /**
@@ -1292,10 +1306,11 @@ class FileLayerProviderTest extends RasterMatchers{
       Files.createDirectories(outDir)
       cubeSpatial.writeGeoTiff(outDir + "/testImpossibleIntersection_" + crsName.replace(":", "_") + ".tiff")
     }
-    if (new DataCubeParameters().useNewFeatureExtentIntersection) {
-      // java.lang.IllegalArgumentException: Could not find data for your load_collection request with catalog ID "Sentinel2". The catalog query had correlation ID "" and returned 4 results.
-      assertThrows[IllegalArgumentException](testImpossibleIntersectionInternal())
-    }
+
+    // Throwing this could also be valid:
+    // java.lang.IllegalArgumentException: Could not find data for your load_collection request with catalog ID "Sentinel2". The catalog query had correlation ID "" and returned 4 results.
+    // Right now, no error is thrown, but the result is empty. To avoid premature errors in confusing cases
+    testImpossibleIntersectionInternal()
   }
 
   @Test
@@ -1303,11 +1318,14 @@ class FileLayerProviderTest extends RasterMatchers{
     val projectedExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
     val poly2 = ProjectedPolygons(projectedExtent)
 
+    val dataCubeParameters = new DataCubeParameters
+    dataCubeParameters.useNewFeatureExtentIntersection2 = true
     val layer = LayerFixtures.creodiasCube(
       LocalDate.of(2020, 8, 1),
       poly2,
       "/org/openeo/geotrellis/testAntimerideanArtifacts.json",
       java.util.Arrays.asList("VV"),
+      dataCubeParameters,
     )
 
     val layer_collected = layer.collect()

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1298,7 +1298,6 @@ class FileLayerProviderTest extends RasterMatchers{
     }
   }
 
-  @Disabled("Test will be fixed in different branch.")
   @Test
   def testAntimerideanArtifacts(): Unit = {
     val projectedExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))


### PR DESCRIPTION
Changes in this MR only change code behind disabled feature flags, and test code.
- Add `useNewFeatureExtentIntersection2` to use better intersection code.
- Use `safeReprojectPolygons()` to avoid artifacts
- When a feature and the target extent don't intersect, still load them. It could be due to an antimeridian issue.
- Added handy `toGeoJsonDebug()`

https://github.com/Open-EO/openeo-geopyspark-driver/issues/1072