### PR TITLE
netcdf: track spatial keys

### DIFF
--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
@@ -110,16 +110,12 @@ package object geotrelliscommon {
     override def toString = s"SparseSpaceTimePartitioner ${indices.length} ${theKeys.isDefined}"
 
     override def spatialKeys: Option[Array[SpatialKey]] = {
-      if (theKeys.isDefined) {
-        Some(theKeys.get.map(_.spatialKey))
-      } else {
-        None
-      }
+      theKeys.map(_.map(_.spatialKey).distinct)
     }
 
   }
 
-  class SparseSpaceOnlyPartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpaceTimeKey]] = Option.empty ) extends PartitionerIndex[SpaceTimeKey] {
+  class SparseSpaceOnlyPartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpaceTimeKey]] = Option.empty ) extends PartitionerIndex[SpaceTimeKey] with SpatialKeysProvider {
 
     def toIndex(key: SpaceTimeKey): BigInt = SparseSpaceOnlyPartitioner.toIndex(key, indexReduction)
 
@@ -141,9 +137,11 @@ package object geotrelliscommon {
       val state = Seq( indexReduction)
       state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
     }
+
+    override def spatialKeys: Option[Array[SpatialKey]] = theKeys.map(_.map(_.spatialKey).distinct)
   }
 
-  class SparseSpatialPartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpatialKey]] = Option.empty ) extends PartitionerIndex[SpatialKey] {
+  class SparseSpatialPartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpatialKey]] = Option.empty ) extends PartitionerIndex[SpatialKey] with SpatialKeysProvider {
 
     def toIndex(key: SpatialKey): BigInt = Z2(key.col,key.row).z >> indexReduction
 
@@ -165,6 +163,8 @@ package object geotrelliscommon {
       val state = Seq( indexReduction)
       state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
     }
+
+    override def spatialKeys: Option[Array[SpatialKey]] = theKeys
   }
 
   class ConfigurableSpatialPartitioner(val indexReduction:Int = 4) extends PartitionerIndex[SpatialKey] {

--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
@@ -62,7 +62,7 @@ package object geotrelliscommon {
   object SparseSpaceOnlyPartitioner {
     // Shift by 8 removes the last 8 bytes: 256 tiles max in one partition.
     def toIndex(key: SpaceTimeKey, indexReduction:Int = 8): BigInt = Z2(key.col,key.row).z >> indexReduction
-    def toIndex(key: SpatialKey, indexReduction:Int = 8): BigInt = Z2(key.col,key.row).z >> indexReduction
+    def toIndex(key: SpatialKey, indexReduction:Int): BigInt = Z2(key.col,key.row).z >> indexReduction
   }
 
   object SparseSpaceTimePartitioner {

--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/package.scala
@@ -46,7 +46,7 @@ package object geotrelliscommon {
 
   }
 
-  object ByTileSpacetimePartitioner extends PartitionerIndex[SpaceTimeKey] {
+  class ByTileSpacetimePartitioner(val theKeys: Option[Array[SpatialKey]] = Option.empty) extends PartitionerIndex[SpaceTimeKey] with SpatialKeysProvider {
     private def toZ(key: SpaceTimeKey): Z2 = Z2(key.col, key.row)
 
     def toIndex(key: SpaceTimeKey): BigInt = toZ(key).z
@@ -54,11 +54,15 @@ package object geotrelliscommon {
     def indexRanges(keyRange: (SpaceTimeKey, SpaceTimeKey)): Seq[(BigInt, BigInt)] =
       Z2.zranges(ZRange(toZ(keyRange._1), toZ(keyRange._2))).map(r => (BigInt(r.lower), BigInt(r.upper)))
 
+    override def spatialKeys: Option[Array[SpatialKey]] = {
+      theKeys
+    }
   }
 
   object SparseSpaceOnlyPartitioner {
     // Shift by 8 removes the last 8 bytes: 256 tiles max in one partition.
     def toIndex(key: SpaceTimeKey, indexReduction:Int = 8): BigInt = Z2(key.col,key.row).z >> indexReduction
+    def toIndex(key: SpatialKey, indexReduction:Int = 8): BigInt = Z2(key.col,key.row).z >> indexReduction
   }
 
   object SparseSpaceTimePartitioner {
@@ -68,7 +72,12 @@ package object geotrelliscommon {
     def toIndex(key: SpaceTimeKey, indexReduction:Int = 8): BigInt = keyIndex.toIndex(key) >> indexReduction
   }
 
-  class SparseSpaceTimePartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpaceTimeKey]] = Option.empty) extends PartitionerIndex[SpaceTimeKey] {
+
+  trait SpatialKeysProvider {
+    def spatialKeys: Option[Array[SpatialKey]]
+  }
+
+  class SparseSpaceTimePartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpaceTimeKey]] = Option.empty) extends PartitionerIndex[SpaceTimeKey] with SpatialKeysProvider {
 
     def toIndex(key: SpaceTimeKey): BigInt = SparseSpaceTimePartitioner.toIndex(key, indexReduction)
 
@@ -99,6 +108,15 @@ package object geotrelliscommon {
 
 
     override def toString = s"SparseSpaceTimePartitioner ${indices.length} ${theKeys.isDefined}"
+
+    override def spatialKeys: Option[Array[SpatialKey]] = {
+      if (theKeys.isDefined) {
+        Some(theKeys.get.map(_.spatialKey))
+      } else {
+        None
+      }
+    }
+
   }
 
   class SparseSpaceOnlyPartitioner (val indices: Array[BigInt], val indexReduction:Int = 8, val theKeys: Option[Array[SpaceTimeKey]] = Option.empty ) extends PartitionerIndex[SpaceTimeKey] {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -27,7 +27,7 @@ import org.apache.spark.{Partitioner, SparkContext}
 import org.openeo.geotrellis.OpenEOProcessScriptBuilder.{MaxIgnoreNoData, MinIgnoreNoData, OpenEOProcess, safeConvert}
 import org.openeo.geotrellis.focal._
 import org.openeo.geotrellis.netcdf.NetCDFRDDWriter.ContextSeq
-import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, ByTileSpatialPartitioner, ConfigurableSpaceTimePartitioner, ConfigurableSpatialPartitionerReduceZ, DatacubeSupport, FFTConvolve, OpenEORasterCube, OpenEORasterCubeMetadata, SCLConvolutionFilter, SpaceTimeByMonthPartitioner, SparseSpaceOnlyPartitioner, SparseSpaceTimePartitioner, SparseSpatialPartitioner}
+import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, ByTileSpatialPartitioner, ConfigurableSpaceTimePartitioner, ConfigurableSpatialPartitionerReduceZ, DatacubeSupport, FFTConvolve, OpenEORasterCube, OpenEORasterCubeMetadata, SCLConvolutionFilter, SpaceTimeByMonthPartitioner, SparseSpaceOnlyPartitioner, SparseSpaceTimePartitioner, SparseSpatialPartitioner, SpatialKeysProvider}
 import org.slf4j.LoggerFactory
 
 import java.io.File
@@ -200,10 +200,10 @@ class OpenEOProcesses extends Serializable {
       if (index.isDefined && (index.get.isInstanceOf[SparseSpaceOnlyPartitioner] || index.get.isInstanceOf[ByTileSpacetimePartitioner] )) {
         datacube
       } else {
-        val keys: Option[Array[SpaceTimeKey]] = findPartitionerSpatialKeys(datacube)
+        val keys: Option[Array[SpatialKey]] = findPartitionerSpatialKeys(datacube)
         val spatiallyGroupingIndex =
           if(keys.isDefined){
-            new SparseSpaceOnlyPartitioner(keys.get.map(SparseSpaceOnlyPartitioner.toIndex(_, indexReduction = 0)).distinct.sorted, 0, keys)
+            new SparseSpaceOnlyPartitioner(keys.get.map(SparseSpaceOnlyPartitioner.toIndex(_, indexReduction = 0)).distinct.sorted, 0, findPartitionerKeys(datacube))
           }else{
             new ByTileSpacetimePartitioner()
           }
@@ -319,7 +319,7 @@ class OpenEOProcesses extends Serializable {
   }
 
   def findPartitionerSpatialKeys(datacube: MultibandTileLayerRDD[SpaceTimeKey]): Option[Array[SpatialKey]] = {
-    val keys: Option[Array[SpaceTimeKey]] = if (datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]]) {
+    val keys: Option[Array[SpatialKey]] = if (datacube.partitioner.isDefined && (datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]] || datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpatialKey]])) {
       val index = datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index
       index match {
         case value: SpatialKeysProvider =>

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -173,8 +173,6 @@ class OpenEOProcesses extends Serializable {
   }
 
     private def transformTimeDimension[KT](datacube: MultibandTileLayerRDD[SpaceTimeKey], scriptBuilder: OpenEOProcessScriptBuilder, context: util.Map[String, Any], reduce:Boolean=false): RDD[(KT, MultibandTile)] = {
-
-
       val expectedCellType = datacube.metadata.cellType
       val applyToTimeseries: Iterable[(SpaceTimeKey, MultibandTile)] => Map[KT, MultibandTile] =
         if(reduce){
@@ -191,8 +189,6 @@ class OpenEOProcesses extends Serializable {
     }
 
   private def transformTimeDimension[KT](datacube: MultibandTileLayerRDD[SpaceTimeKey],applyToTimeseries: Iterable[(SpaceTimeKey, MultibandTile)] => Map[KT, MultibandTile],  reduce:Boolean ): RDD[(KT, MultibandTile)] = {
-
-
     val index: Option[PartitionerIndex[SpaceTimeKey]] =
       if (datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]]) {
         Some(datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index)
@@ -201,15 +197,15 @@ class OpenEOProcesses extends Serializable {
       }
     logger.info(s"Applying callback on time dimension of cube with partitioner: ${datacube.partitioner.getOrElse("no partitioner")} - index: ${index.getOrElse("no index")} and metadata ${datacube.metadata}")
     val rdd: RDD[(SpaceTimeKey, MultibandTile)] =
-      if (index.isDefined && (index.get.isInstanceOf[SparseSpaceOnlyPartitioner] || index.get == ByTileSpacetimePartitioner )) {
+      if (index.isDefined && (index.get.isInstanceOf[SparseSpaceOnlyPartitioner] || index.get.isInstanceOf[ByTileSpacetimePartitioner] )) {
         datacube
       } else {
-        val keys: Option[Array[SpaceTimeKey]] = findPartitionerKeys(datacube)
+        val keys: Option[Array[SpaceTimeKey]] = findPartitionerSpatialKeys(datacube)
         val spatiallyGroupingIndex =
           if(keys.isDefined){
             new SparseSpaceOnlyPartitioner(keys.get.map(SparseSpaceOnlyPartitioner.toIndex(_, indexReduction = 0)).distinct.sorted, 0, keys)
           }else{
-            ByTileSpacetimePartitioner
+            new ByTileSpacetimePartitioner()
           }
         logger.info(f"Regrouping data cube along the time dimension, with index $spatiallyGroupingIndex. Cube metadata: ${datacube.metadata}")
         val partitioner: Partitioner = new SpacePartitioner(datacube.metadata.bounds)(implicitly, implicitly, spatiallyGroupingIndex)
@@ -289,10 +285,10 @@ class OpenEOProcesses extends Serializable {
 
     val newBounds = retiled.metadata.bounds.asInstanceOf[KeyBounds[SpaceTimeKey]].toSpatial
 
-    val keys = findPartitionerKeys(datacube)
+    val keys = findPartitionerSpatialKeys(datacube)
     val spatiallyGroupingIndex =
       if(keys.isDefined){
-        val spatialKeys: Array[SpatialKey] = keys.get.map(_.spatialKey).distinct
+        val spatialKeys: Array[SpatialKey] = keys.get
         new SparseSpatialPartitioner(spatialKeys.map(ByTileSpatialPartitioner.toIndex).distinct.sorted, 0, Some(spatialKeys))
       }else{
         ByTileSpatialPartitioner
@@ -306,11 +302,11 @@ class OpenEOProcesses extends Serializable {
   private def groupOnTimeDimension(datacube: MultibandTileLayerRDD[SpaceTimeKey]) = {
     val targetBounds = datacube.metadata.bounds.asInstanceOf[KeyBounds[SpaceTimeKey]].toSpatial
 
-    val keys: Option[Array[SpaceTimeKey]] = findPartitionerKeys(datacube)
+    val keys: Option[Array[SpatialKey]] = findPartitionerSpatialKeys(datacube)
 
     val index =
       if (keys.isDefined) {
-        new SparseSpatialPartitioner(keys.get.map(SparseSpaceOnlyPartitioner.toIndex(_, indexReduction = 0)).distinct.sorted, 0, keys.map(_.map(_.spatialKey)))
+        new SparseSpatialPartitioner(keys.get.map(SparseSpaceOnlyPartitioner.toIndex(_, indexReduction = 0)).distinct.sorted, 0, keys)
       } else {
         ByTileSpatialPartitioner
       }
@@ -322,6 +318,20 @@ class OpenEOProcesses extends Serializable {
     groupedOnTime
   }
 
+  def findPartitionerSpatialKeys(datacube: MultibandTileLayerRDD[SpaceTimeKey]): Option[Array[SpatialKey]] = {
+    val keys: Option[Array[SpaceTimeKey]] = if (datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]]) {
+      val index = datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index
+      index match {
+        case value: SpatialKeysProvider =>
+          value.spatialKeys
+        case _ =>
+          Option.empty
+      }
+    } else {
+      Option.empty
+    }
+    keys
+  }
 
   def findPartitionerKeys(datacube: MultibandTileLayerRDD[SpaceTimeKey]): Option[Array[SpaceTimeKey]] = {
     val keys: Option[Array[SpaceTimeKey]] = if (datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]]) {
@@ -461,9 +471,9 @@ class OpenEOProcesses extends Serializable {
 
     val filteredCube = filterNegativeSpatialKeys(datacube)
 
-    val keys = findPartitionerKeys(filteredCube).map(_.filter( k => k.row >= 0 && k.col >= 0 ))
+    val keys = findPartitionerSpatialKeys(filteredCube).map(_.filter( k => k.row >= 0 && k.col >= 0 ))
     val allPossibleKeys: immutable.Seq[SpatialKey] = if(keys.isDefined) {
-      keys.get.map(_.spatialKey).distinct.toList
+      keys.get.distinct.toList
     } else{
       filteredCube.metadata.tileBounds
         .coordsIter
@@ -480,7 +490,7 @@ class OpenEOProcesses extends Serializable {
       }else{
         if (datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]]) {
           val index = datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index
-          if (index.isInstanceOf[SparseSpaceOnlyPartitioner] || index == ByTileSpacetimePartitioner) {
+          if (index.isInstanceOf[SparseSpaceOnlyPartitioner] || index.isInstanceOf[ByTileSpacetimePartitioner]) {
             index//a space only partitioner does not care about time, so can be reused as-is
           } else {
             SpaceTimeByMonthPartitioner

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -727,7 +727,7 @@ class OpenEOProcesses extends Serializable {
         implicit val newIndex: PartitionerIndex[K] = new SparseSpaceOnlyPartitioner(newIndices,leftPart.index.asInstanceOf[SparseSpaceOnlyPartitioner].indexReduction).asInstanceOf[PartitionerIndex[K]]
         SpacePartitioner[K](kb)(implicitly,implicitly,newIndex)
       }
-      else if(leftPart.index == rightPart.index && (leftPart.index == ByTileSpatialPartitioner || leftPart.index == ByTileSpacetimePartitioner)) {
+      else if(leftPart.index == rightPart.index && (leftPart.index == ByTileSpatialPartitioner || leftPart.index.isInstanceOf[ByTileSpacetimePartitioner])) {
         leftPart
       }
       else if(leftPart.index == rightPart.index && leftPart.index.isInstanceOf[ConfigurableSpaceTimePartitioner] ) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/OpenEOProcesses.scala
@@ -547,7 +547,7 @@ class OpenEOProcesses extends Serializable {
 
     val tilesByInterval: RDD[(SpaceTimeKey, MultibandTile)] =
       if(reduce) {
-        if(datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]] && (datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index.isInstanceOf[SparseSpaceOnlyPartitioner] || datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index == ByTileSpacetimePartitioner )) {
+        if(datacube.partitioner.isDefined && datacube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]] && (datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index.isInstanceOf[SparseSpaceOnlyPartitioner] || datacube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index.isInstanceOf[ByTileSpacetimePartitioner] )) {
           filteredCube.mapPartitions(elements =>{
             val byNewKey= elements.flatMap(mapToNewKey).toStream.groupBy(_._1)
             byNewKey.mapValues(v=>aggregateTiles(v.map(_._2))).iterator

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/NetCDFCollection.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/NetCDFCollection.scala
@@ -107,7 +107,7 @@ object NetCDFCollection {
     val spatialBounds = KeyBounds(layout.mapTransform(extent))
     val temporalBounds = KeyBounds(SpaceTimeKey(spatialBounds.minKey,TemporalKey(LocalDate.of(1990,1,1).atStartOfDay(ZoneId.of("UTC")))),SpaceTimeKey(spatialBounds.maxKey,TemporalKey(LocalDate.now().atStartOfDay(ZoneId.of("UTC")))))
 
-    val keys: Array[SpatialKey] =  items.map(_.geometry.get).clipToGrid(layout).map(_._1).distinct().collect()
+    val keys: Array[SpatialKey] =  items.map(i => i.geometry.getOrElse(i.bbox.toPolygon())).clipToGrid(layout).map(_._1).distinct().collect()
     val partitioner: Partitioner = new SpacePartitioner(temporalBounds)(implicitly, implicitly, new ByTileSpacetimePartitioner(Some(keys)))
 
     val metadata = TileLayerMetadata[SpaceTimeKey](cellType, layout, extent, crs(0), temporalBounds)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/NetCDFCollection.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/NetCDFCollection.scala
@@ -107,7 +107,8 @@ object NetCDFCollection {
     val spatialBounds = KeyBounds(layout.mapTransform(extent))
     val temporalBounds = KeyBounds(SpaceTimeKey(spatialBounds.minKey,TemporalKey(LocalDate.of(1990,1,1).atStartOfDay(ZoneId.of("UTC")))),SpaceTimeKey(spatialBounds.maxKey,TemporalKey(LocalDate.now().atStartOfDay(ZoneId.of("UTC")))))
 
-    val partitioner: Partitioner = new SpacePartitioner(temporalBounds)(implicitly, implicitly, ByTileSpacetimePartitioner)
+    val keys: Array[SpatialKey] =  items.map(_.geometry.get).clipToGrid(layout).map(_._1).distinct().collect()
+    val partitioner: Partitioner = new SpacePartitioner(temporalBounds)(implicitly, implicitly, new ByTileSpacetimePartitioner(Some(keys)))
 
     val metadata = TileLayerMetadata[SpaceTimeKey](cellType, layout, extent, crs(0), temporalBounds)
     val retiled: RDD[(SpaceTimeKey, MultibandTile)] = features.tileToLayout(metadata).partitionBy(partitioner)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
@@ -31,7 +31,7 @@ import org.openeo.geotrellis.aggregate_polygon.intern.splitOverlappingPolygons
 import org.openeo.geotrellis.aggregate_polygon.{AggregatePolygonProcess, SparkAggregateScriptBuilder}
 import org.openeo.geotrellis.file.Sentinel2RadiometryPyramidFactory
 import org.openeo.geotrellis.geotiff.{ContextSeq, saveRDD}
-import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, SparseSpaceOnlyPartitioner}
+import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, DatacubeSupport, SpaceTimeByMonthPartitioner, SparseSpaceOnlyPartitioner}
 import org.openeo.sparklisteners.GetInfoSparkListener
 
 import java.nio.file.{Files, Paths}
@@ -502,11 +502,12 @@ class OpenEOProcessesSpec extends RasterMatchers {
   def aggregateTemporalTest(pixelType: PixelType, index: PartitionerIndex[SpaceTimeKey]): Unit = {
     val outDir = "/tmp/aggregateTemporalTest/"
     Files.createDirectories(Paths.get(outDir))
-    var layer: MultibandTileLayerRDD[SpaceTimeKey] = LayerFixtures.randomNoiseLayer(pixelType)
+    var cube: MultibandTileLayerRDD[SpaceTimeKey] = LayerFixtures.randomNoiseLayer(pixelType)
     if(index != null) {
-      layer = layer.withContext(_.partitionBy(new SpacePartitioner[SpaceTimeKey](layer.metadata.bounds)(implicitly, implicitly, index)))
+      cube = cube.withContext(_.partitionBy(new SpacePartitioner[SpaceTimeKey](cube.metadata.bounds)(implicitly, implicitly, index)))
     }
-    val bounds = layer.metadata.bounds
+
+    val bounds = cube.metadata.bounds
     val middleDate = SpaceTimeKey(0, 0, (bounds.get.minKey.instant + bounds.get.maxKey.instant) / 2).time
 
     // intervals is a list of start,end-pairs
@@ -514,12 +515,22 @@ class OpenEOProcessesSpec extends RasterMatchers {
       .map(DateTimeFormatter.ISO_INSTANT.format(_))
     val labels = (intervals.indices.collect { case i if i % 2 == 0 => intervals(i) }).toList
 
-    val resultTiles: Array[MultibandTile] = new OpenEOProcesses().aggregateTemporal(layer,
+    val aggregatedCube = new OpenEOProcesses().aggregateTemporal(cube,
       intervals.asJava,
       labels.asJava,
-      TestOpenEOProcessScriptBuilder.createMedian(true,layer.metadata.cellType),
+      TestOpenEOProcessScriptBuilder.createMedian(true, cube.metadata.cellType),
       java.util.Collections.emptyMap()
-    ).values.collect()
+    )
+
+    assertTrue(aggregatedCube.partitioner.get.isInstanceOf[SpacePartitioner[SpaceTimeKey]])
+    val aggregatedIndex = aggregatedCube.partitioner.get.asInstanceOf[SpacePartitioner[SpaceTimeKey]].index
+    index match {
+      case value: ByTileSpacetimePartitioner =>
+        assertTrue(aggregatedIndex.isInstanceOf[ByTileSpacetimePartitioner])
+      case _ =>
+        assertTrue(aggregatedIndex == SpaceTimeByMonthPartitioner)
+    }
+    val resultTiles: Array[MultibandTile] = aggregatedCube.values.collect()
 
     val validTile = resultTiles.find(_ != null).get
     val emptyTile = ArrayMultibandTile.empty(validTile.cellType, validTile.bandCount, validTile.cols, validTile.rows)
@@ -534,7 +545,7 @@ class OpenEOProcessesSpec extends RasterMatchers {
       case _ => throw new IllegalStateException(s"pixelType $pixelType not supported")
     }
 
-    GeoTiff(Raster(MultibandTile(filledResult), layer.metadata.extent), layer.metadata.crs)
+    GeoTiff(Raster(MultibandTile(filledResult), cube.metadata.extent), cube.metadata.crs)
       .write(outDir + pixelType + ".tiff", optimizedOrder = true)
 
     val builder = new SparkAggregateScriptBuilder
@@ -543,11 +554,11 @@ class OpenEOProcessesSpec extends RasterMatchers {
     builder.expressionEnd("max", emptyMap)
     builder.expressionEnd("mean", emptyMap)
 
-    val geometries = ProjectedPolygons.fromExtent(layer.metadata.extent, layer.metadata.crs.toString())
+    val geometries = ProjectedPolygons.fromExtent(cube.metadata.extent, cube.metadata.crs.toString())
     val splitPolygons = splitOverlappingPolygons(geometries.polygons)
     val outDirSpacial = outDir + pixelType
-    new AggregatePolygonProcess().aggregateSpatialGeneric(scriptBuilder = builder, datacube = layer, polygonsWithIndexMapping = splitPolygons,
-      geometries.crs, bandCount = new OpenEOProcesses().RDDBandCount(layer), outDirSpacial)
+    new AggregatePolygonProcess().aggregateSpatialGeneric(scriptBuilder = builder, datacube = cube, polygonsWithIndexMapping = splitPolygons,
+      geometries.crs, bandCount = new OpenEOProcesses().RDDBandCount(cube), outDirSpacial)
 
     val groupedStats = parseCSV(outDirSpacial)
     for ((_, stats) <- groupedStats) pixelType match {

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
@@ -438,12 +438,15 @@ class OpenEOProcessesSpec extends RasterMatchers {
 
   @Test
   def medianComposite(): Unit = {
-    val withoutPartitioner = medianCompositeImpl(false)
-    val withPartitioner = medianCompositeImpl(true)
+    val withoutPartitioner = medianCompositeImpl(None)
+    val sparsePartitioner = medianCompositeImpl(Some( new SparseSpaceOnlyPartitioner(Array[BigInt](0, 1, 2, 3, 4), 8)))
+    val byTilePartitioner = medianCompositeImpl(Some( new ByTileSpacetimePartitioner()))
     println("withoutPartitioner:")
     withoutPartitioner.printStatus()
-    println("withPartitioner:")
-    withPartitioner.printStatus()
+    println("sparsePartitioner:")
+    sparsePartitioner.printStatus()
+    println("byTilePartitioner:")
+    byTilePartitioner.printStatus()
     // Measurements at 2022-01-18:
 
     // [stagesCompleted]  | no #90 fix | #90 fix
@@ -458,20 +461,22 @@ class OpenEOProcessesSpec extends RasterMatchers {
     // assertEquals(withoutPartitioner.getStagesCompleted, withPartitioner.getStagesCompleted)
     // might need to change threshold in the future:
     assertTrue(
-      "withPartitioner.getTasksCompleted should be smaller than 15. Actually: " + withPartitioner.getTasksCompleted,
-      withPartitioner.getTasksCompleted < 15,
+      "sparsePartitioner.getTasksCompleted should be smaller than 15. Actually: " + sparsePartitioner.getTasksCompleted,
+      sparsePartitioner.getTasksCompleted < 15,
+    )
+    assertTrue(
+      "byTilePartitioner.getTasksCompleted should be smaller than 6. Actually: " + byTilePartitioner.getTasksCompleted,
+      byTilePartitioner.getTasksCompleted < 6,
     )
   }
 
-  def medianCompositeImpl(usePartitioner: Boolean): GetInfoSparkListener = {
+  def medianCompositeImpl(partitioner: Option[PartitionerIndex[SpaceTimeKey]]): GetInfoSparkListener = {
     var layer: MultibandTileLayerRDD[SpaceTimeKey] = LayerFixtures.sentinel2B04Layer
 
-    if (usePartitioner) {
+    if (partitioner.isDefined) {
       type K = SpaceTimeKey
       val kb: Bounds[K] = layer.metadata.getComponent[Bounds[K]]
-      val newIndices: Array[BigInt] = Array[BigInt](0, 1, 2, 3, 4)
-      implicit val newIndex: PartitionerIndex[K] = new SparseSpaceOnlyPartitioner(newIndices, 8).asInstanceOf[PartitionerIndex[K]]
-      val p = SpacePartitioner[K](kb)(implicitly,implicitly,newIndex)
+      val p = SpacePartitioner[K](kb)(implicitly,implicitly,partitioner.get)
 
       val tmp = layer.partitionBy(p)
       layer = MultibandTileLayerRDD[SpaceTimeKey](tmp, layer.metadata)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
@@ -458,7 +458,7 @@ class OpenEOProcessesSpec extends RasterMatchers {
     // assertEquals(withoutPartitioner.getStagesCompleted, withPartitioner.getStagesCompleted)
     // might need to change threshold in the future:
     assertTrue(
-      "withPartitioner.getTasksCompleted should be smaller than 13. Actually: " + withPartitioner.getTasksCompleted,
+      "withPartitioner.getTasksCompleted should be smaller than 15. Actually: " + withPartitioner.getTasksCompleted,
       withPartitioner.getTasksCompleted < 15,
     )
   }
@@ -471,7 +471,7 @@ class OpenEOProcessesSpec extends RasterMatchers {
       val kb: Bounds[K] = layer.metadata.getComponent[Bounds[K]]
       val newIndices: Array[BigInt] = Array[BigInt](0, 1, 2, 3, 4)
       implicit val newIndex: PartitionerIndex[K] = new SparseSpaceOnlyPartitioner(newIndices, 8).asInstanceOf[PartitionerIndex[K]]
-      val p = SpacePartitioner[K](kb)
+      val p = SpacePartitioner[K](kb)(implicitly,implicitly,newIndex)
 
       val tmp = layer.partitionBy(p)
       layer = MultibandTileLayerRDD[SpaceTimeKey](tmp, layer.metadata)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/OpenEOProcessesSpec.scala
@@ -31,7 +31,7 @@ import org.openeo.geotrellis.aggregate_polygon.intern.splitOverlappingPolygons
 import org.openeo.geotrellis.aggregate_polygon.{AggregatePolygonProcess, SparkAggregateScriptBuilder}
 import org.openeo.geotrellis.file.Sentinel2RadiometryPyramidFactory
 import org.openeo.geotrellis.geotiff.{ContextSeq, saveRDD}
-import org.openeo.geotrelliscommon.SparseSpaceOnlyPartitioner
+import org.openeo.geotrelliscommon.{ByTileSpacetimePartitioner, SparseSpaceOnlyPartitioner}
 import org.openeo.sparklisteners.GetInfoSparkListener
 
 import java.nio.file.{Files, Paths}
@@ -133,6 +133,13 @@ object OpenEOProcessesSpec {
     tile.set(0, 0, 1)
     tile.set(0, 1, tile.cellType.noDataValue)
     tile
+  }
+
+  def aggregateTemporalTestParams(): java.util.stream.Stream[Arguments] = {
+    val pixelTypes = PixelType.values()
+    val p1 = new ByTileSpacetimePartitioner()
+    pixelTypes.flatMap(pt => Seq( arguments(pt, null),arguments(pt, p1))).toStream.asJava.stream()
+
   }
 }
 
@@ -489,12 +496,16 @@ class OpenEOProcessesSpec extends RasterMatchers {
     listener
   }
 
+
   @ParameterizedTest
-  @EnumSource(classOf[PixelType])
-  def aggregateTemporalTest(pixelType: PixelType): Unit = {
+  @MethodSource(Array("aggregateTemporalTestParams"))
+  def aggregateTemporalTest(pixelType: PixelType, index: PartitionerIndex[SpaceTimeKey]): Unit = {
     val outDir = "/tmp/aggregateTemporalTest/"
     Files.createDirectories(Paths.get(outDir))
-    val layer: MultibandTileLayerRDD[SpaceTimeKey] = LayerFixtures.randomNoiseLayer(pixelType)
+    var layer: MultibandTileLayerRDD[SpaceTimeKey] = LayerFixtures.randomNoiseLayer(pixelType)
+    if(index != null) {
+      layer = layer.withContext(_.partitionBy(new SpacePartitioner[SpaceTimeKey](layer.metadata.bounds)(implicitly, implicitly, index)))
+    }
     val bounds = layer.metadata.bounds
     val middleDate = SpaceTimeKey(0, 0, (bounds.get.minKey.instant + bounds.get.maxKey.instant) / 2).time
 


### PR DESCRIPTION
Improve the interface to get spatial keys from a partitioner, reducing 'if else' style code paths.

https://github.com/Open-EO/openeo-geopyspark-driver/issues/1146 
https://github.com/Open-EO/openeo-geotrellis-extensions/issues/43