### PR TITLE
Dateline 20250416

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -259,14 +259,14 @@ object ProjectedPolygons {
    * Inspired on reprojectExtentAsPolygon from geotrellis. I could not find an equivalent for polygons in geotrellis self:
    * https://github.com/pomadchin/geotrellis/blob/b071b33/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala#L94
    */
-  def reprojectPolygonRefined(polygon: Polygon, transform: Transform, relError: Double): Polygon = {
+  def reprojectPolygonRefined(polygon: Polygon, transform: Transform, absError: Double): Polygon = {
     var interiorRings = List[LineString]()
     for (ringNr <- 0 until polygon.getNumInteriorRing) {
       val shell = polygon.getInteriorRingN(ringNr).asInstanceOf[LineString]
-      interiorRings = interiorRings :+ reprojectRingRefined(shell, transform, relError)
+      interiorRings = interiorRings :+ reprojectRingRefined(shell, transform, absError)
     }
     val shell = polygon.getExteriorRing
-    val refined = reprojectRingRefined(shell, transform, relError)
+    val refined = reprojectRingRefined(shell, transform, absError)
     Polygon(refined, interiorRings)
   }
 
@@ -274,7 +274,7 @@ object ProjectedPolygons {
    * Inspired on reprojectExtentAsPolygon from geotrellis. I could not find an equivalent for polygons in geotrellis self:
    * https://github.com/pomadchin/geotrellis/blob/b071b33/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala#L94
    */
-  private def reprojectRingRefined(shell: LineString, transform: Transform, relError: Double): LineString = {
+  private def reprojectRingRefined(shell: LineString, transform: Transform, absError: Double): LineString = {
     import math.{abs, pow, sqrt}
 
     def refine(p0: (Point, (Double, Double)), p1: (Point, (Double, Double))): List[(Point, (Double, Double))] = {
@@ -288,7 +288,7 @@ object ProjectedPolygons {
       val p2 = m -> (x2, y2)
       if (java.lang.Double.isNaN(deflect)) {
         throw new IllegalArgumentException(s"Encountered NaN during a refinement step: ($deflect / $length). Input $shell is likely not in source projection.")
-      } else if (deflect / length < relError) {
+      } else if (deflect < absError) {
         List(p2)
       } else {
         refine(p0, p2) ++ (p2 :: refine(p2, p1))
@@ -300,11 +300,11 @@ object ProjectedPolygons {
     LineString(refined.map { case (_, (x, y)) => Point(x, y) })
   }
 
-  def reprojectGeometryRefined(geom: Geometry, transform: Transform, relError: Double): Geometry = {
+  def reprojectGeometryRefined(geom: Geometry, transform: Transform, absError: Double): Geometry = {
     geom match {
-      case polygon: Polygon => reprojectPolygonRefined(polygon, transform, 0.001)
+      case polygon: Polygon => reprojectPolygonRefined(polygon, transform, absError)
       case multiPolygon: MultiPolygon =>
-        MultiPolygon(multiPolygon.polygons.map(reprojectPolygonRefined(_, transform, 0.001)))
+        MultiPolygon(multiPolygon.polygons.map(reprojectPolygonRefined(_, transform, absError)))
       case geometry: Geometry =>
         // logger.info("Was only expecting (Multi)Polygon, but got: " + geometry)
         geometry

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -66,7 +66,8 @@ case class ProjectedPolygons(geometries: Array[Geometry], crs: CRS) {
   def safeReproject(crs: CRS, refine: Boolean): ProjectedPolygons = safeReprojectPolygons(this, crs, refine)
 
   def riskOfCrossingAntimeridian: Boolean = {
-    val p = this.getFlatMultiPolygon.reproject(crs, LatLng) // Without refining
+    val transform = SafeTransform(crs, LatLng)  // be sure 0-360 polygons don't cause issues.
+    val p = this.getFlatMultiPolygon.reproject(transform) // Without refining
     val xList = p.getCoordinates.map(c => to_min180_180_range(c.x))
     val allCloseToZeroMeridian = xList.forall(x => Math.abs(x) <= 90)
     if (allCloseToZeroMeridian) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/ProjectedPolygons.scala
@@ -64,6 +64,26 @@ case class ProjectedPolygons(geometries: Array[Geometry], crs: CRS) {
   def extent: ProjectedExtent = ProjectedExtent(polygons.toSeq.extent,crs)
   def reproject(crs: CRS): ProjectedPolygons = ProjectedPolygons.reproject(this, crs)
   def safeReproject(crs: CRS, refine: Boolean): ProjectedPolygons = safeReprojectPolygons(this, crs, refine)
+
+  def riskOfCrossingAntimeridian: Boolean = {
+    val p = this.getFlatMultiPolygon.reproject(crs, LatLng) // Without refining
+    val xList = p.getCoordinates.map(c => to_min180_180_range(c.x))
+    val allCloseToZeroMeridian = xList.forall(x => Math.abs(x) <= 90)
+    if (allCloseToZeroMeridian) {
+      false
+    } else {
+      val closeToAntimeridian = xList.exists(x => Math.abs(x) > 178)
+      if (closeToAntimeridian) {
+        // We did not reproject refined for this one, so take some margin
+        true
+      } else {
+        // If the polygon crosses both sides, it should cross the antimeridian
+        val westernHemisphere = xList.exists(x => x < 0)
+        val easternHemisphere = xList.exists(x => x < 0)
+        westernHemisphere && easternHemisphere
+      }
+    }
+  }
 }
 
 object ProjectedPolygons {
@@ -230,7 +250,6 @@ object ProjectedPolygons {
   }
 
   def polygon_to_min180_180_range(p: Polygon): Polygon = {
-    // Documentation says CoordinateSequenceFilter should be used, but that has a complex interface
     val clearlyWesternHemisphere = p.getCoordinates.exists(c => (c.x < 0 && c.x > -180) || (c.x > +180 && c.x < +360))
     val clearlyEasternHemisphere = p.getCoordinates.exists(c => (c.x > 0 && c.x < +180) || (c.x < -180 && c.x > -360))
     p.getCoordinates.foreach(c => {
@@ -259,14 +278,14 @@ object ProjectedPolygons {
    * Inspired on reprojectExtentAsPolygon from geotrellis. I could not find an equivalent for polygons in geotrellis self:
    * https://github.com/pomadchin/geotrellis/blob/b071b33/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala#L94
    */
-  def reprojectPolygonRefined(polygon: Polygon, transform: Transform, absError: Double): Polygon = {
+  def reprojectPolygonRefined(polygon: Polygon, transform: Transform, relError: Double, treatXIn360: Boolean): Polygon = {
     var interiorRings = List[LineString]()
     for (ringNr <- 0 until polygon.getNumInteriorRing) {
       val shell = polygon.getInteriorRingN(ringNr).asInstanceOf[LineString]
-      interiorRings = interiorRings :+ reprojectRingRefined(shell, transform, absError)
+      interiorRings = interiorRings :+ reprojectRingRefined(shell, transform, relError, treatXIn360)
     }
     val shell = polygon.getExteriorRing
-    val refined = reprojectRingRefined(shell, transform, absError)
+    val refined = reprojectRingRefined(shell, transform, relError, treatXIn360)
     Polygon(refined, interiorRings)
   }
 
@@ -274,13 +293,17 @@ object ProjectedPolygons {
    * Inspired on reprojectExtentAsPolygon from geotrellis. I could not find an equivalent for polygons in geotrellis self:
    * https://github.com/pomadchin/geotrellis/blob/b071b33/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala#L94
    */
-  private def reprojectRingRefined(shell: LineString, transform: Transform, absError: Double): LineString = {
+  private def reprojectRingRefined(shell: LineString, transform: Transform, relError: Double, treatXIn360: Boolean): LineString = {
     import math.{abs, pow, sqrt}
 
     def refine(p0: (Point, (Double, Double)), p1: (Point, (Double, Double))): List[(Point, (Double, Double))] = {
-      val ((a, (x0, y0)), (b, (x1, y1))) = (p0, p1)
+      val ((a, (x0_orig, y0)), (b, (x1_orig, y1))) = (p0, p1)
+      val x0 = if (treatXIn360) to_0_360_range(x0_orig) else x0_orig
+      val x1 = if (treatXIn360) to_0_360_range(x1_orig) else x1_orig
+
       val m = Point(0.5 * (a.x + b.x), 0.5 * (a.y + b.y))
-      val (x2, y2) = transform(m.x, m.y)
+      val (x2_orig, y2) = transform(m.x, m.y)
+      val x2 = if (treatXIn360) to_0_360_range(x2_orig) else x2_orig
 
       val deflect = abs((y2 - y1) * x0 - (x2 - x1) * y0 + x2 * y1 - y2 * x1) / sqrt(pow(y2 - y1, 2) + pow(x2 - x1, 2))
       val length = sqrt(pow(x0 - x1, 2) + pow(y0 - y1, 2))
@@ -288,7 +311,7 @@ object ProjectedPolygons {
       val p2 = m -> (x2, y2)
       if (java.lang.Double.isNaN(deflect)) {
         throw new IllegalArgumentException(s"Encountered NaN during a refinement step: ($deflect / $length). Input $shell is likely not in source projection.")
-      } else if (deflect < absError) {
+      } else if (deflect / length < relError) {
         List(p2)
       } else {
         refine(p0, p2) ++ (p2 :: refine(p2, p1))
@@ -300,11 +323,11 @@ object ProjectedPolygons {
     LineString(refined.map { case (_, (x, y)) => Point(x, y) })
   }
 
-  def reprojectGeometryRefined(geom: Geometry, transform: Transform, absError: Double): Geometry = {
+  def reprojectGeometryRefined(geom: Geometry, transform: Transform, relError: Double, treatXIn360: Boolean = false): Geometry = {
     geom match {
-      case polygon: Polygon => reprojectPolygonRefined(polygon, transform, absError)
+      case polygon: Polygon => reprojectPolygonRefined(polygon, transform, relError, treatXIn360)
       case multiPolygon: MultiPolygon =>
-        MultiPolygon(multiPolygon.polygons.map(reprojectPolygonRefined(_, transform, absError)))
+        MultiPolygon(multiPolygon.polygons.map(reprojectPolygonRefined(_, transform, relError, treatXIn360)))
       case geometry: Geometry =>
         // logger.info("Was only expecting (Multi)Polygon, but got: " + geometry)
         geometry

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -915,7 +915,7 @@ object FileLayerProvider {
         eoProductFeature.mapGeom(productGeometry => {
           try {
             val intersection = if (datacubeParams.getOrElse(new DataCubeParameters).useNewFeatureExtentIntersection2) {
-              val productGeometryProjected = safeReprojectPolygons(ProjectedPolygons(productGeometry, LatLng), productCRSOrDefault)
+              val productGeometryProjected = ProjectedPolygons(productGeometry, LatLng).safeReproject(productCRSOrDefault, refine = true)
 
               val cubeExtentCrs = ProjectedExtent(cubeExtent, targetCRS)
               val cubeExtentPolygon = safeReprojectToPolygon(cubeExtentCrs, productCRSOrDefault)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -416,9 +416,20 @@ package object geotrellis {
   def safeReprojectPolygons(inputProjectedPolygons: ProjectedPolygons, targetCrs: CRS, refine:Boolean = false): ProjectedPolygons = {
     if (inputProjectedPolygons.crs == targetCrs) return inputProjectedPolygons
     val transform = SafeTransform(inputProjectedPolygons.crs, targetCrs)
+    val targetIsUTM = targetCrs.proj4jCrs.getProjection.getName == "utm"
     val geometries = if (refine) {
+      // TODO: Better heuristic for absError.
+      //  Based on layer resolution?
+      //  10cm everywhere? -> Only for equidistant projections.
+      val absError = if (targetCrs == LatLng) {
+        0.0001
+      } else if (targetIsUTM) {
+        0.01 // utm defines distances in meters
+      } else {
+        0.1 // TODO
+      }
       inputProjectedPolygons.geometries.map {
-        reprojectGeometryRefined(_, transform, 0.001)
+        reprojectGeometryRefined(_, transform, absError)
       }
     } else {
       inputProjectedPolygons.geometries.map(_.reproject(transform))

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/package.scala
@@ -392,8 +392,10 @@ package object geotrellis {
 
   def polygonWrapAntimeridian(polygon: Polygon): Polygon = {
     // This trick is mainly for GLOBAL-MOSAICS, where a product geometry is not split on the antimeridian
+    // Should only be called when you know the Polygon should not be covering more than half of the world.
+    // For example when projecting from UTM.
     val polygonCopy = polygon.copy().asInstanceOf[Polygon]
-    if (polygon.extent.width > 180 && polygon.extent.width < 360) {
+    if (polygon.extent.width > 180) {
       // Documentation says CoordinateSequenceFilter should be used, but that has a complex interface
       polygonCopy.getCoordinates.foreach(c => c.x = to_0_360_range(c.x))
     }
@@ -416,27 +418,17 @@ package object geotrellis {
   def safeReprojectPolygons(inputProjectedPolygons: ProjectedPolygons, targetCrs: CRS, refine:Boolean = false): ProjectedPolygons = {
     if (inputProjectedPolygons.crs == targetCrs) return inputProjectedPolygons
     val transform = SafeTransform(inputProjectedPolygons.crs, targetCrs)
-    val targetIsUTM = targetCrs.proj4jCrs.getProjection.getName == "utm"
+    val inputIsUTM = inputProjectedPolygons.crs.proj4jCrs.getProjection.getName == "utm"
+    val treatXIn360 = inputIsUTM && targetCrs == LatLng && inputProjectedPolygons.riskOfCrossingAntimeridian
     val geometries = if (refine) {
-      // TODO: Better heuristic for absError.
-      //  Based on layer resolution?
-      //  10cm everywhere? -> Only for equidistant projections.
-      val absError = if (targetCrs == LatLng) {
-        0.0001
-      } else if (targetIsUTM) {
-        0.01 // utm defines distances in meters
-      } else {
-        0.1 // TODO
-      }
       inputProjectedPolygons.geometries.map {
-        reprojectGeometryRefined(_, transform, absError)
+        reprojectGeometryRefined(_, transform, 0.001, treatXIn360 = treatXIn360)
       }
     } else {
       inputProjectedPolygons.geometries.map(_.reproject(transform))
     }
     var pp = ProjectedPolygons(geometries, targetCrs)
-    val inputIsUTM = inputProjectedPolygons.crs.proj4jCrs.getProjection.getName == "utm"
-    if (inputIsUTM && targetCrs == LatLng) {
+    if (treatXIn360) {
       // When the extent was utm, some wrapping may have occurred
       pp = projectedPolygonWrapAntimeridian(pp)
     }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ProjectedPolygonsTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ProjectedPolygonsTest.scala
@@ -106,11 +106,12 @@ class ProjectedPolygonsTest() {
     ))), CRS.fromName("EPSG:32660"))
     dumpGeoJson(toGeoJsonDebug(pp), Some("testRefineToLatLngOverAntimeridian"))
 
-    val ppReprojected = pp.safeReproject(LatLng, refine = true)
-    ppReprojected.splitPolygonsOnWrapPoint()
+    val ppReprojected = projectedPolygonWrapAntimeridian(pp.safeReproject(LatLng, refine = true))
     val pReprojected = ppReprojected.getFlatMultiPolygon
     assertTrue(pReprojected.union().getArea > 0)
     // Prepare to manually inspect output in QGIS:
     dumpGeoJson(toGeoJsonDebug(ppReprojected), Some("testRefineToLatLngOverAntimeridian_reprojected"))
+    ppReprojected.splitPolygonsOnWrapPoint()  // test if error is thrown.
+    // TODO: Compare with reference geojson?
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ProjectedPolygonsTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/ProjectedPolygonsTest.scala
@@ -73,26 +73,44 @@ class ProjectedPolygonsTest() {
       ppSplit.geometries.foreach(g => assertTrue(g.isValid))
     }
     assertTrue(ppSplit.getFlatMultiPolygon.union().getArea > 0)
+    println(pp.riskOfCrossingAntimeridian)
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array(
     "/org/openeo/geotrellis/geojson/belgium_lowres.json",
     "/org/openeo/geotrellis/geojson/swiss_holes.json",
+    "/org/openeo/geotrellis/geojson/bering_sea_triangle.json",
   ))
   def testReprojectPolygonWithTesslation(path: String): Unit = {
     val pp = ProjectedPolygons.fromVectorFile(getClass.getResource(path).getPath)
     val targetCrs = CRS.fromEpsgCode(32631)
-    val transform = SafeTransform(LatLng, targetCrs)
-    val p = pp.getFlatMultiPolygon
 
     val ppReprojectedOld = safeReprojectPolygons(pp, targetCrs)
-    val pReprojected = reprojectPolygonRefined(p.polygons.head, transform, 1.0)
-    val ppReprojected = ProjectedPolygons(pReprojected, targetCrs)
-    assertTrue(pReprojected.union().getArea > 0)
+    val ppReprojected = pp.safeReproject(targetCrs, refine = true)
+    assertTrue(ppReprojected.getFlatMultiPolygon.union().getArea > 0)
 
     // Prepare to manually inspect output in QGIS:
     dumpGeoJson(toGeoJsonDebug(ppReprojectedOld), Some(path.substring(path.lastIndexOf("/") + 1) + "_reprojectedOld_" + targetCrs))
     dumpGeoJson(toGeoJsonDebug(ppReprojected), Some(path.substring(path.lastIndexOf("/") + 1) + "_reprojected_" + targetCrs))
+  }
+
+  @Test
+  def testRefineToLatLngOverAntimeridian(): Unit = {
+    val pointBegin = Point(611000, 7666000)
+    val pp = ProjectedPolygons(Polygon(LineString(Seq(
+      pointBegin,
+      Point(599000, 7801000),
+      Point(728000, 7751000),
+      pointBegin,
+    ))), CRS.fromName("EPSG:32660"))
+    dumpGeoJson(toGeoJsonDebug(pp), Some("testRefineToLatLngOverAntimeridian"))
+
+    val ppReprojected = pp.safeReproject(LatLng, refine = true)
+    ppReprojected.splitPolygonsOnWrapPoint()
+    val pReprojected = ppReprojected.getFlatMultiPolygon
+    assertTrue(pReprojected.union().getArea > 0)
+    // Prepare to manually inspect output in QGIS:
+    dumpGeoJson(toGeoJsonDebug(ppReprojected), Some("testRefineToLatLngOverAntimeridian_reprojected"))
   }
 }

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1400,13 +1400,13 @@ class FileLayerProviderTest extends RasterMatchers{
 
   @Test
   def testAntimerideanArtifacts3(): Unit = {
-    val outDir = Paths.get("tmp/testAntimerideanArtifacts2/")
+    val outDir = Paths.get("tmp/testAntimerideanArtifacts3/")
     new Directory(outDir.toFile).deepFiles.foreach(_.delete())
     Files.createDirectories(outDir)
 
     val projectedExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
     val spatialExtent = ProjectedPolygons(projectedExtent).reproject(CRS.fromName("EPSG:32660"))
-    dumpGeoJson(toGeoJsonDebug(spatialExtent), Some("testAntimerideanArtifacts2"))
+    dumpGeoJson(toGeoJsonDebug(spatialExtent), Some("testAntimerideanArtifacts3"))
     // DataCubeParameters taken from running as sync job.
     val dataCubeParameters = new DataCubeParameters
     dataCubeParameters.tileSize = 128 // only difference with testAntimerideanArtifacts2
@@ -1435,7 +1435,7 @@ class FileLayerProviderTest extends RasterMatchers{
     val layer = cube.head._2
     val cubeSpatial = layer.toSpatial()
 
-    val tiffPath = outDir + "/testAntimerideanArtifacts2.tiff"
+    val tiffPath = outDir + "/testAntimerideanArtifacts3.tiff"
     cubeSpatial.writeGeoTiff(tiffPath)
 
     // Read back and check values:

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1399,6 +1399,54 @@ class FileLayerProviderTest extends RasterMatchers{
   }
 
   @Test
+  def testAntimerideanArtifacts3(): Unit = {
+    val outDir = Paths.get("tmp/testAntimerideanArtifacts2/")
+    new Directory(outDir.toFile).deepFiles.foreach(_.delete())
+    Files.createDirectories(outDir)
+
+    val projectedExtent = ProjectedExtent(Extent(300000, 7690200, 409800, 7800000), CRS.fromName("EPSG:32601"))
+    val spatialExtent = ProjectedPolygons(projectedExtent).reproject(CRS.fromName("EPSG:32660"))
+    dumpGeoJson(toGeoJsonDebug(spatialExtent), Some("testAntimerideanArtifacts2"))
+    // DataCubeParameters taken from running as sync job.
+    val dataCubeParameters = new DataCubeParameters
+    dataCubeParameters.tileSize = 128 // only difference with testAntimerideanArtifacts2
+    dataCubeParameters.layoutScheme = "FloatingLayoutScheme"
+    dataCubeParameters.partitionerIndexReduction = 6
+    dataCubeParameters.useNewFeatureExtentIntersection = true
+    dataCubeParameters.useNewFeatureExtentIntersection2 = true
+    dataCubeParameters.globalExtent = Some(ProjectedExtent(Extent(526300.0, 7682200.0, 646340.0, 7802240.0), CRS.fromName("EPSG:32660")))
+
+    val factory = new PyramidFactory(
+      loadFeaturesWithArtifactoryMock("/org/openeo/geotrellis/testAntimerideanArtifacts2.json"),
+      "GLOBAL-MOSAICS",
+      java.util.Arrays.asList("VV"),
+      "/eodata",
+      maxSpatialResolution = CellSize(20, 20)
+    )
+    factory.crs = spatialExtent.crs
+
+    val cube: Seq[(Int, MultibandTileLayerRDD[SpaceTimeKey])] = factory.datacube_seq(
+      spatialExtent,
+      "2020-07-31T23:59:59Z",
+      "2020-09-01T00:00:00Z",
+      scala.collection.Map[String, Any]("productType" -> "S1SAR_L3_IW_MCM").asJava,
+      "", dataCubeParameters = dataCubeParameters
+    )
+    val layer = cube.head._2
+    val cubeSpatial = layer.toSpatial()
+
+    val tiffPath = outDir + "/testAntimerideanArtifacts2.tiff"
+    cubeSpatial.writeGeoTiff(tiffPath)
+
+    // Read back and check values:
+    val result = GeoTiff.readMultiband(tiffPath).raster.tile
+    val band = result.toArrayTile().band(0)
+    val value = band.get(4444, 5118) // Read on location where artifact would be
+    assertEquals(0.02, value, 1) // TODO: Update actual value, smaller delta
+    // Maybe better check: assertTrue(value != -2.147483648E9)
+  }
+
+  @Test
   def testMissingS2DateLineOutside(): Unit = {
     if (!new DataCubeParameters().useNewFeatureExtentIntersection) {
       return

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1236,11 +1236,14 @@ class FileLayerProviderTest extends RasterMatchers{
     // geojson only officially supports latLon, but QGIS handles custom CRSes
     Files.writeString(Paths.get(outDir + "/" + uniqueName + ".geojson"), poly2GeoJson)
 
+    val dataCubeParameters = new DataCubeParameters
+    dataCubeParameters.useNewFeatureExtentIntersection = true
+
     val layer = LayerFixtures.sentinel2Cube(
       LocalDate.of(2024, 4, 2),
       poly2,
       "/org/openeo/geotrellis/testMissingS2DateLine.json",
-      new DataCubeParameters,
+      dataCubeParameters,
       java.util.Arrays.asList("IMG_DATA_Band_SCL_20m_Tile1_Data"),
     )
 
@@ -1266,10 +1269,6 @@ class FileLayerProviderTest extends RasterMatchers{
   @ValueSource(strings = Array("EPSG:32601", "EPSG:32660", "EPSG:4326", "EPSG:3857"))
   def testMissingS2DateLine(crsName: String): Unit = {
     // typically requires PROJ_LIB to be set
-    if (crsName == "EPSG:32660" && !new DataCubeParameters().useNewFeatureExtentIntersection) {
-      return
-    }
-
     for (tup <- Seq(
       (Extent(178.1, 70.3, 178.9, 70.9), "left"),
       (Extent(-179.9, 70.1, -179.2, 71.3), "right"),
@@ -1345,9 +1344,8 @@ class FileLayerProviderTest extends RasterMatchers{
 
     val result = GeoTiff.readMultiband(tiffPath).raster.tile
     val band = result.toArrayTile().band(0)
-    val value = band.get(7500, 10000) // Read on location where artifact would be
-    assertEquals(0.02, value, 1) // TODO: Update actual value, smaller delta
-    // Maybe better check: assertTrue(value != -2.147483648E9)
+    val value = band.getDouble(7500, 10000) // Read on location where artifact would be
+    assertEquals(0.0303, value, 0.1)
   }
 
   @Test
@@ -1393,9 +1391,8 @@ class FileLayerProviderTest extends RasterMatchers{
     // Read back and check values:
     val result = GeoTiff.readMultiband(tiffPath).raster.tile
     val band = result.toArrayTile().band(0)
-    val value = band.get(4600, 5115) // Read on location where artifact would be
-    assertEquals(0.02, value, 1) // TODO: Update actual value, smaller delta
-    // Maybe better check: assertTrue(value != -2.147483648E9)
+    val value = band.getDouble(4600, 5115) // Read on location where artifact would be
+    assertEquals(0.0281, value, 0.1)
   }
 
   @Test
@@ -1441,9 +1438,8 @@ class FileLayerProviderTest extends RasterMatchers{
     // Read back and check values:
     val result = GeoTiff.readMultiband(tiffPath).raster.tile
     val band = result.toArrayTile().band(0)
-    val value = band.get(4444, 5118) // Read on location where artifact would be
-    assertEquals(0.02, value, 1) // TODO: Update actual value, smaller delta
-    // Maybe better check: assertTrue(value != -2.147483648E9)
+    val value = band.getDouble(4444, 5118) // Read on location where artifact would be
+    assertEquals(0.0227, value, 0.1)
   }
 
   @Test


### PR DESCRIPTION
The issue is that the refine step changes it's resolution depending on the length of the line segment.
Giving weird refinements like this (product 2020_M08_60WWC_1_0):
![image](https://github.com/user-attachments/assets/a68b4f5c-d017-47e8-9d55-d58984cd2fcb)

The bottom side of this rectangle caused an artifact

https://github.com/Open-EO/openeo-geopyspark-driver/issues/1072