### PR TITLE
fix: explicit credentials for waw3-1

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -49,8 +49,9 @@ object CreoS3Utils {
 
   def getCreoS3Client(region: Region = cloudFerroRegion): S3Client = {
     val endpointURI = if (region != cloudFerroRegion) this.getCFEndpoin(region) else URI.create(sys.env("SWIFT_URL"))
+    val credProvider = if (region == Region.of("waw3-1")) credentialsProviderWAW31 else credentialsProvider
     S3Client.builder()
-      .credentialsProvider(credentialsProvider)
+      .credentialsProvider(credProvider)
       .serviceConfiguration(S3Configuration.builder().checksumValidationEnabled(false).build())
       .overrideConfiguration(overrideConfig)
       .forcePathStyle(true)
@@ -68,6 +69,13 @@ object CreoS3Utils {
     val swiftAccess = sys.env.getOrElse("SWIFT_ACCESS_KEY_ID", sys.env.getOrElse("AWS_ACCESS_KEY_ID", ""))
     val swiftSecretAccess = sys.env.getOrElse("SWIFT_SECRET_ACCESS_KEY", sys.env.getOrElse("AWS_SECRET_ACCESS_KEY", ""))
     val credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(swiftAccess, swiftSecretAccess))
+    credentialsProvider
+  }
+
+  private def credentialsProviderWAW31 = {
+    val s3AccessKeyId = sys.env.getOrElse("WAW31_ACCESS_KEY_ID", "")
+    val s3SecretKey = sys.env.getOrElse("WAW31_SECRET_ACCESS_KEY", "")
+    val credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(s3AccessKeyId, s3SecretKey))
     credentialsProvider
   }
 


### PR DESCRIPTION
In order to allow operating with a region different then waw3-1 as main region we should be able to handle WAW3-1 explicitly.