### PR TITLE
426 load collection option to not filter out empty tiles

### DIFF
--- a/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/DataCubeParameters.scala
+++ b/geotrellis-common/src/main/scala/org/openeo/geotrelliscommon/DataCubeParameters.scala
@@ -33,6 +33,12 @@ class DataCubeParameters extends Serializable {
    */
   var maxPartitionSize: Option[Int] = None
 
+  /**
+   * Whether to filter out MultibandTiles that are empty (i.e. all bands are NODATA),
+   * or to keep them as EmptyMultiBandTiles.
+   */
+  var retainNoDataTiles: Boolean = false
+
   override def toString = s"DataCubeParameters($tileSize, $maskingStrategyParameters, $layoutScheme, $partitionerTemporalResolution, $partitionerIndexReduction, $maskingCube, $resampleMethod, $pixelBufferX, $pixelBufferY)"
 
   def setPartitionerIndexReduction(reduction:Int): Unit = partitionerIndexReduction = reduction

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/geotiff/PyramidFactory.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/geotiff/PyramidFactory.scala
@@ -224,7 +224,7 @@ class PyramidFactory private (rasterSources: => Seq[(RasterSource, ZonedDateTime
       tiledLayoutSource.source.extent.interiorIntersects(tiledLayoutSource.layout.extent)
     })
     FileLayerProvider.readMultibandTileLayer(filteredSources, layerMetadata,
-      Array(MultiPolygon(toPolygon(theBoundingBox.extent))), theBoundingBox.crs, sc, retainNoDataTiles = false,
+      Array(MultiPolygon(toPolygon(theBoundingBox.extent))), theBoundingBox.crs, sc,
       datacubeParams = Some(params))
 
   }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -345,9 +345,9 @@ object FileLayerProvider {
   def apply(openSearch: OpenSearchClient, openSearchCollectionId: String, openSearchLinkTitles: NonEmptyList[String], rootPath: String,
             maxSpatialResolution: CellSize, pathDateExtractor: PathDateExtractor, attributeValues: Map[String, Any] = Map(), layoutScheme: LayoutScheme = ZoomedLayoutScheme(WebMercator, 256),
             bandIndices: Seq[Int] = Seq(), correlationId: String = "", experimental: Boolean = false,
-            retainNoDataTiles: Boolean = false, maxSoftErrorsRatio: Double = 0.0): FileLayerProvider = new FileLayerProvider(
+            maxSoftErrorsRatio: Double = 0.0): FileLayerProvider = new FileLayerProvider(
     openSearch, openSearchCollectionId, openSearchLinkTitles, rootPath, maxSpatialResolution, pathDateExtractor,
-    attributeValues, layoutScheme, bandIndices, correlationId, experimental, retainNoDataTiles, maxSoftErrorsRatio,
+    attributeValues, layoutScheme, bandIndices, correlationId, experimental, maxSoftErrorsRatio,
     disambiguateConstructors = null
   )
 
@@ -394,13 +394,13 @@ object FileLayerProvider {
     tiledLayoutSourceRDD
   }
 
-  def readMultibandTileLayer(rasterSources: RDD[LayoutTileSource[SpaceTimeKey]], metadata: TileLayerMetadata[SpaceTimeKey], polygons: Array[MultiPolygon], polygons_crs: CRS, sc: SparkContext, retainNoDataTiles: Boolean, cloudFilterStrategy: CloudFilterStrategy = NoCloudFilterStrategy, useSparsePartitioner: Boolean = true, datacubeParams : Option[DataCubeParameters] = None): RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]] = {
+  def readMultibandTileLayer(rasterSources: RDD[LayoutTileSource[SpaceTimeKey]], metadata: TileLayerMetadata[SpaceTimeKey], polygons: Array[MultiPolygon], polygons_crs: CRS, sc: SparkContext, cloudFilterStrategy: CloudFilterStrategy = NoCloudFilterStrategy, useSparsePartitioner: Boolean = true, datacubeParams : Option[DataCubeParameters] = None): RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]] = {
     val polygonsRDD = sc.parallelize(polygons).map {
       _.reproject(polygons_crs, metadata.crs)
     }
     // The requested polygons dictate which SpatialKeys will be read from the source files/streams.
     var requiredSpatialKeys: RDD[(SpatialKey, Iterable[Geometry])] = polygonsRDD.clipToGrid(metadata.layout).groupByKey()
-
+    val retainNoDataTiles = datacubeParams.exists(_.retainNoDataTiles)
     tileSourcesToDataCube(rasterSources, metadata, requiredSpatialKeys, sc, retainNoDataTiles, cloudFilterStrategy, useSparsePartitioner, datacubeParams)
   }
 
@@ -678,7 +678,19 @@ object FileLayerProvider {
       }
       MultibandTile(mergedBands.toSeq.sortBy(_._1).flatMap(_._2.get.bands))
 
-    } ).filter { case (_, tile) => retainNoDataTiles ||  !tile.bands.forall(_.isNoDataTile) }
+    } )
+    val withEmptyTiles = if (retainNoDataTiles) {
+      tiledRDD.map { case (key, tile) =>
+        if (tile.bands.forall(_.isNoDataTile)) {
+          (key, new EmptyMultibandTile(tile.cols, tile.rows, tile.cellType, tile.bandCount))
+        } else {
+          (key, tile)
+        }
+      }
+    } else {
+      tiledRDD
+    }
+    tiledRDD = withEmptyTiles.filter { case (_, tile) => retainNoDataTiles ||  !tile.bands.forall(_.isNoDataTile) }
 
     rasterRegionRDD.sparkContext.setCallSite("load_collection: apply mask pixel wise")
     tiledRDD = DatacubeSupport.applyDataMask(datacubeParams,tiledRDD,metadata, pixelwiseMasking = true)
@@ -708,24 +720,34 @@ object FileLayerProvider {
       rasterRegionRDD
         .groupByKey(partitioner)
         .mapPartitions(partitionIterator => {
-          var totalPixelsPartition = 0
-          val startTime = System.currentTimeMillis()
+          val loadedRDD = {
+            var totalPixelsPartition = 0
+            val startTime = System.currentTimeMillis()
 
-          val (loadedPartitions,partitionPixels) = loadPartition(partitionIterator, cloudFilterStrategy, totalChunksAcc, tracker,crs,layout )
-          totalPixelsPartition += partitionPixels
+            val (loadedPartitions, partitionPixels) = loadPartition(partitionIterator, cloudFilterStrategy, totalChunksAcc, tracker, crs, layout)
+            totalPixelsPartition += partitionPixels
 
-          val durationMillis = System.currentTimeMillis() - startTime
-          if (totalPixelsPartition > 0) {
-            val secondsPerChunk = (durationMillis / 1000.0) / (totalPixelsPartition / (256 * 256))
-            loadingTimeAcc.add(secondsPerChunk)
+            val durationMillis = System.currentTimeMillis() - startTime
+            if (totalPixelsPartition > 0) {
+              val secondsPerChunk = (durationMillis / 1000.0) / (totalPixelsPartition / (256 * 256))
+              loadingTimeAcc.add(secondsPerChunk)
+            }
+            loadedPartitions
           }
-          loadedPartitions
-
-        }
-          .filter { case (_, tile) => retainNoDataTiles || tile.isDefined && !tile.get.bands.forall(_.isNoDataTile) }
-          .map(t => (t._1,t._2.get)).iterator,
-          preservesPartitioning = true)
-
+          val withEmptyTiles = if (retainNoDataTiles) {
+            loadedRDD.map { case (key, tile) =>
+              if (tile.get.bands.forall(_.isNoDataTile)) {
+                (key, Some(new EmptyMultibandTile(tile.get.cols, tile.get.rows, tile.get.cellType, tile.get.bandCount)))
+              } else {
+                (key, tile)
+              }
+            }
+          } else {
+            loadedRDD
+          }
+          withEmptyTiles.filter { case (_, tile) => tile.isDefined && (retainNoDataTiles || !tile.get.bands.forall(_.isNoDataTile)) }
+            .map(t => (t._1, t._2.get)).iterator
+        }, preservesPartitioning = true)
     tiledRDD = DatacubeSupport.applyDataMask(datacubeParams,tiledRDD,metadata, pixelwiseMasking = true)
 
     val cRDD = ContextRDD(tiledRDD, metadata)
@@ -969,8 +991,7 @@ object FileLayerProvider {
 class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollectionId: String, openSearchLinkTitles: NonEmptyList[String], rootPath: String,
                         maxSpatialResolution: CellSize, pathDateExtractor: PathDateExtractor, attributeValues: Map[String, Any], layoutScheme: LayoutScheme,
                         bandIndices: Seq[Int], correlationId: String, experimental: Boolean,
-                        retainNoDataTiles: Boolean, maxSoftErrorsRatio: Double,
-                        disambiguateConstructors: Null) extends LayerProvider { // workaround for: constructors have the same type after erasure
+                        maxSoftErrorsRatio: Double, disambiguateConstructors: Null) extends LayerProvider { // workaround for: constructors have the same type after erasure
 
   import DatacubeSupport._
   import FileLayerProvider._
@@ -980,7 +1001,7 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
   def this(openSearch: OpenSearchClient, openSearchCollectionId: String, openSearchLinkTitles: NonEmptyList[String], rootPath: String,
            maxSpatialResolution: CellSize, pathDateExtractor: PathDateExtractor, attributeValues: Map[String, Any] = Map(), layoutScheme: LayoutScheme = ZoomedLayoutScheme(WebMercator, 256),
            bandIds: Seq[Seq[Int]] = Seq(), correlationId: String = "", experimental: Boolean = false,
-           retainNoDataTiles: Boolean = false, maxSoftErrorsRatio: Double = 0.0) = this(openSearch, openSearchCollectionId,
+           maxSoftErrorsRatio: Double = 0.0) = this(openSearch, openSearchCollectionId,
            openSearchLinkTitles = NonEmptyList.fromListUnsafe(for {
              (title, bandIndices) <- openSearchLinkTitles.toList.zipAll(bandIds, thisElem = "", thatElem = Seq(0))
              _ <- bandIndices
@@ -988,7 +1009,7 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
            rootPath, maxSpatialResolution, pathDateExtractor, attributeValues, layoutScheme,
            bandIndices = bandIds.flatten,
            correlationId, experimental,
-           retainNoDataTiles, maxSoftErrorsRatio, disambiguateConstructors = null)
+           maxSoftErrorsRatio, disambiguateConstructors = null)
 
   assert(bandIndices.isEmpty || bandIndices.size == openSearchLinkTitles.size)
 
@@ -1357,8 +1378,9 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
       val theMaskStrategy: CloudFilterStrategy = maskStrategy.getOrElse(NoCloudFilterStrategy)
 
       //convert to raster region
+      val retainNoDataTiles = datacubeParams.exists(_.retainNoDataTiles)
       val cube=
-        if(!datacubeParams.map(_.loadPerProduct).getOrElse(false) || theMaskStrategy != NoCloudFilterStrategy ){
+        if(!datacubeParams.exists(_.loadPerProduct) || theMaskStrategy != NoCloudFilterStrategy ){
           rasterRegionsToTiles(regions, metadata, retainNoDataTiles, theMaskStrategy, partitioner, datacubeParams)
         }else{
           rasterRegionsToTilesLoadPerProductStrategy(regions, metadata, retainNoDataTiles, NoCloudFilterStrategy, partitioner, datacubeParams, openSearchLinkTitlesWithBandId.size,readKeysToRasterSourcesResult._4, softErrors)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -169,6 +169,27 @@ class FileLayerProviderTest extends RasterMatchers{
   }
 
   @Test
+  def retainNoDataTilesTest(): Unit = {
+    val bbox1 = ProjectedExtent(Extent(xmin = 0.0, ymin = 0.0, xmax = 30.0, ymax = 10.0), LatLng)
+    val bbox2 = ProjectedExtent(Extent(xmin = 50.0, ymin = 20.0, xmax = 60.0, ymax = 40.0), LatLng)
+    val fullBbox = ProjectedExtent(bbox1.extent.combine(bbox2.extent), LatLng)
+    val date = LocalDate.of(2020, 1, 1).atStartOfDay(ZoneId.of("UTC"))
+
+    val params = new DataCubeParameters()
+    params.layoutScheme = "FloatingLayoutScheme"
+    params.globalExtent = Some(fullBbox)
+    params.tileSize = 64
+    params.retainNoDataTiles = true
+
+    val polygons1 = MultiPolygon(fullBbox.extent.toPolygon())
+    val (rasterSources1, metadata1) = _getSentinel5PRasterSources(fullBbox, date, 0)
+    val resultRetainNoDatatiles = FileLayerProvider.readMultibandTileLayer(rasterSources1, metadata1, Array(polygons1),
+      fullBbox.crs, sc, NoCloudFilterStrategy, datacubeParams=Some(params))
+    val resultRetainNoDatatilesColl = resultRetainNoDatatiles.collect()
+    assertEquals(1, resultRetainNoDatatilesColl.count(_._2.isInstanceOf[EmptyMultibandTile]))
+  }
+
+  @Test
   def sparsePartitionerTest(): Unit = {
     val bbox1 = ProjectedExtent(Extent(xmin = 0.0, ymin = 0.0, xmax = 30.0, ymax = 10.0), LatLng)
     val bbox2 = ProjectedExtent(Extent(xmin = 50.0, ymin = 20.0, xmax = 60.0, ymax = 40.0), LatLng)
@@ -245,10 +266,10 @@ class FileLayerProviderTest extends RasterMatchers{
     val polygons1 = MultiPolygon(bbox1.extent.toPolygon())
     val (rasterSources1, metadata1) = _getSentinel5PRasterSources(bbox1, date, zoom)
     val sparseBaseLayer = FileLayerProvider.readMultibandTileLayer(rasterSources1, metadata1, Array(polygons1),
-      bbox1.crs, sc, retainNoDataTiles = false,
+      bbox1.crs, sc,
       NoCloudFilterStrategy)
     val defaultBaseLayer = FileLayerProvider.readMultibandTileLayer(rasterSources1, metadata1, Array(polygons1),
-      bbox1.crs, sc, retainNoDataTiles = false,
+      bbox1.crs, sc,
       NoCloudFilterStrategy,
       useSparsePartitioner = false)
 
@@ -257,10 +278,10 @@ class FileLayerProviderTest extends RasterMatchers{
     val polygons2 = MultiPolygon(bbox2.extent.toPolygon())
     val (rasterSources2, metadata2) = _getSentinel5PRasterSources(bbox1, date, zoom)
     val sparseBaseLayer2 = FileLayerProvider.readMultibandTileLayer(rasterSources2, metadata2, Array(polygons2),
-      bbox2.crs, sc, retainNoDataTiles = false,
+      bbox2.crs, sc,
       NoCloudFilterStrategy)
     val defaultBaseLayer2 = FileLayerProvider.readMultibandTileLayer(rasterSources2, metadata2, Array(polygons2),
-      bbox2.crs, sc, retainNoDataTiles = false,
+      bbox2.crs, sc,
       NoCloudFilterStrategy,
       useSparsePartitioner = false)
 
@@ -282,10 +303,10 @@ class FileLayerProviderTest extends RasterMatchers{
     val polygons = MultiPolygon(bbox.extent.toPolygon())
     val (rasterSources, metadata) = _getSentinel5PRasterSources(bbox, date, 8)
     val sparseBaseLayer = FileLayerProvider.readMultibandTileLayer(rasterSources, metadata, Array(polygons),
-      bbox.crs, sc, retainNoDataTiles = false,
+      bbox.crs, sc,
       NoCloudFilterStrategy)
     val defaultBaseLayer = FileLayerProvider.readMultibandTileLayer(rasterSources, metadata, Array(polygons),
-      bbox.crs, sc, retainNoDataTiles = false,
+      bbox.crs, sc,
       NoCloudFilterStrategy,
       useSparsePartitioner = false)
 


### PR DESCRIPTION
- new retainNoDataTiles datacube parameter
- adds EmptyMultibandTile if all bands have `isNoDataTile` tiles
- reuses old retainNoDataTiles property from FileLayerProvider that was not used anymore