### PR TITLE
Adaptive metadata partitioner indexreduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix thresholds in `linear_scale_range` to trigger type casting ([openeo-geopyspark-driver#1275](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1275))
 - Major performance improvement for load_collection/load_stac of (very) sparse datacubes   ([#465](https://github.com/Open-EO/openeo-geotrellis-extensions/issues/465))
-
+- load_collection/load_stac: reduce number of tasks and thus resource use by making partitioner settings adaptive

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -25,7 +25,7 @@ import net.jodah.failsafe.{Failsafe, RetryPolicy}
 import net.jodah.failsafe.event.ExecutionAttemptedEvent
 import org.apache.spark.{HashPartitioner, Partitioner, SparkContext}
 import org.apache.spark.rdd.{CoGroupedRDD, RDD}
-import org.apache.spark.util.LongAccumulator
+import org.apache.spark.util.{LongAccumulator, SizeEstimator}
 import org.locationtech.jts.geom.Geometry
 import org.openeo.geotrellis.OpenEOProcessScriptBuilder.AnyProcess
 import org.openeo.geotrellis.file.{AbstractPyramidFactory, FixedFeaturesOpenSearchClient}
@@ -856,7 +856,7 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
 
     var overlappingRasterSources: Seq[(RasterSource, Feature)] = loadRasterSourceRDD(ProjectedExtent(alignedExtent.extent,reprojectedBoundingBox.crs), from, to, zoom, datacubeParams, Some(worldLayout.cellSize))
 
-    val dates = overlappingRasterSources.map(_._2.nominalDate.toLocalDate.atStartOfDay(ZoneId.of("UTC")))
+    val dates = overlappingRasterSources.map(_._2.nominalDate.toLocalDate.atStartOfDay(ZoneId.of("UTC"))).distinct
 
     var commonCellType: CellType = determineCelltype(overlappingRasterSources)
 
@@ -917,10 +917,14 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
             /**
              * Max size of metadata partition depends on the number of items returned by the catalog.
              * Too many partitions requires extra executors, often at the very beginning of a job, so we try to limit this.
-             *
+             * We use the number of dates as a proxy for the max number of items intersecting a given spatial key.
+             * For cases like Sentinel-2, we can however have  items intersecting at a given location on the same date.
              */
-            val maxRecordsPerPartition = 4048
-            val maxSpatialKeysPerPartition = maxRecordsPerPartition / overlappingRasterSources
+            val maxPartitionSizeBytes = 20 * 1024 * 1024
+            val sampleCount = math.min(10, overlappingRasterSources.size)
+            val averageItemSizeInBytes = overlappingRasterSources.take(sampleCount).map(item => SizeEstimator.estimate(item)).sum / sampleCount
+            val estimatedSizePerKey = averageItemSizeInBytes * dates.length
+            val maxSpatialKeysPerPartition = maxPartitionSizeBytes / estimatedSizePerKey
             var indexReduction = math.max(math.ceil(math.log(maxSpatialKeysPerPartition) / math.log(2)).toInt - 1, 1)
             SpacePartitioner(metadata.bounds.get.toSpatial)(implicitly,implicitly,new ConfigurableSpatialPartitioner(indexReduction))
           }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -920,12 +920,12 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
              * We use the number of dates as a proxy for the max number of items intersecting a given spatial key.
              * For cases like Sentinel-2, we can however have  items intersecting at a given location on the same date.
              */
-            val maxPartitionSizeBytes = 20 * 1024 * 1024
+            val maxPartitionSizeBytes = 30 * 1024 * 1024
             val sampleCount = math.min(10, overlappingRasterSources.size)
             val averageItemSizeInBytes = overlappingRasterSources.take(sampleCount).map(item => SizeEstimator.estimate(item)).sum / sampleCount
             val estimatedSizePerKey = averageItemSizeInBytes * dates.length
             val maxSpatialKeysPerPartition = maxPartitionSizeBytes / estimatedSizePerKey
-            var indexReduction = math.max(math.ceil(math.log(maxSpatialKeysPerPartition) / math.log(2)).toInt - 1, 1)
+            val indexReduction = math.max(math.ceil(math.log(maxSpatialKeysPerPartition) / math.log(2)).toInt - 1, 1)
             SpacePartitioner(metadata.bounds.get.toSpatial)(implicitly,implicitly,new ConfigurableSpatialPartitioner(indexReduction))
           }
         }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -913,7 +913,16 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
             // processing a low number of spatial keys. This can happen with sparse data loading.
             new HashPartitioner(math.max((spatialKeyCount / 100).intValue(),1))
           }else{
-            SpacePartitioner(metadata.bounds.get.toSpatial)(implicitly,implicitly,new ConfigurableSpatialPartitioner(3))
+
+            /**
+             * Max size of metadata partition depends on the number of items returned by the catalog.
+             * Too many partitions requires extra executors, often at the very beginning of a job, so we try to limit this.
+             *
+             */
+            val maxRecordsPerPartition = 4048
+            val maxSpatialKeysPerPartition = maxRecordsPerPartition / overlappingRasterSources
+            var indexReduction = math.max(math.ceil(math.log(maxSpatialKeysPerPartition) / math.log(2)).toInt - 1, 1)
+            SpacePartitioner(metadata.bounds.get.toSpatial)(implicitly,implicitly,new ConfigurableSpatialPartitioner(indexReduction))
           }
         }
 

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/LayerFixtures.scala
@@ -187,7 +187,7 @@ object LayerFixtures {
 
 
   def sentinel1Sigma0LayerProviderUTM =
-    FileLayerProvider(
+    new FileLayerProvider(
       client,
       "urn:eop:VITO:CGS_S1_GRD_SIGMA0_L1",
       openSearchLinkTitles = NonEmptyList.of("VV"),
@@ -196,7 +196,9 @@ object LayerFixtures {
       pathDateExtractor,
       layoutScheme = FloatingLayoutScheme(256),
       experimental = false
-    )
+    ){
+      override def determineCelltype(overlappingRasterSources: Seq[(RasterSource, OpenSearchResponses.Feature)]): CellType = FloatConstantNoDataCellType
+    }
 
   def s2_fapar(from_date:String = "2017-11-01T00:00:00Z", to_date:String="2017-11-16T02:00:00Z", polygons:Seq[Polygon],crs:String) = {
     val parameters = new DataCubeParameters

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -1598,7 +1598,7 @@ class FileLayerProviderTest extends RasterMatchers{
 
     assertEquals(1, listener.getJobsCompleted)
     assertEquals(3, listener.getStagesCompleted)
-    assertEquals(501, listener.getTasksCompleted)
+    assertEquals(21, listener.getTasksCompleted)
     assertEquals(77314, allTiles.size)
     println(listener.getPeakMemoryMB)
 


### PR DESCRIPTION
Drastically reduces stage size for the metadata stages, in an adaptive way to avoid going out of memory on for instance long timeseries.
Tests show that this reduces overall stage computation time (less overhead of many small tasks).
In a test, stage size went from 360 tasks to 10 tasks, which also reduce pressure on spark to allocate executors. Hence the overall executor utilization also improved.