### PR TITLE
access: access to buckets needed for processing

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
@@ -44,7 +44,7 @@ class MultiClientRangeReaderProvider extends S3RangeReaderProvider {
           CreoS3Utils.getCreoS3Client(Region.of("waw3-1"))
         } else if (s3Uri.getBucket.toLowerCase().startsWith("hr-vpp-products-") || s3Uri.getBucket.toLowerCase() == "topography") {
           CreoS3Utils.getCreoS3Client(Region.of("waw3-1"))
-        } else if (s3Uri.getBucket.toLowerCase().contains("waw4-1")) {
+        } else if (s3Uri.getBucket.toLowerCase().contains("waw4-1") || s3Uri.getBucket.toLowerCase().startsWith("landsat-bimonthly-mosaics-")) {
           //For moved buckets we should still go to waw4-1
           CreoS3Utils.getCreoS3Client(Region.of("waw4-1"))
         } else if (swiftEndpoint.toString.contains("waw4-1") || swiftEndpoint.toString.contains("otc")) {


### PR DESCRIPTION
A set of buckets which are publicly available but if you sign with the wrong access key or go to the wrong region access will still fail. This change makes sure waw4-1 is used.