### PR TITLE
Optimize chunk size when global extent < 256x256 pixel

### DIFF
--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -1075,7 +1075,7 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
       if( (extent.extent.width <= maxSpatialResolution.width) || (extent.extent.height <= maxSpatialResolution.height ) ){
         FloatingLayoutScheme(32)
       }else{
-        val rasterExtent = RasterExtent(datacubeParams.map(_.globalExtent.getOrElse(extent)).getOrElse(extent).extent, maxSpatialResolution)
+        val rasterExtent = RasterExtent(datacubeParams.map(_.globalExtent.getOrElse(extent).reproject(extent.crs)).getOrElse(extent.extent), maxSpatialResolution)
         val minTiles = math.min(math.floor(rasterExtent.rows / 256), math.floor(rasterExtent.cols / 256)).toInt
         val tileSize:Int = {
           if (datacubeParams.isDefined && datacubeParams.get.tileSize != 256) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/layers/FileLayerProvider.scala
@@ -1080,9 +1080,9 @@ class FileLayerProvider private(openSearch: OpenSearchClient, openSearchCollecti
         val tileSize:Int = {
           if (datacubeParams.isDefined && datacubeParams.get.tileSize != 256) {
             datacubeParams.get.tileSize
-          }/*else if(rasterExtent.cols<256 && rasterExtent.rows<256) {
-            math.max(nextPowerOfTwo(rasterExtent.cols), nextPowerOfTwo(rasterExtent.rows)).toInt
-          }*/
+          }else if(rasterExtent.cols<256 && rasterExtent.rows<256) {
+            math.max(16, math.max(nextPowerOfTwo(rasterExtent.cols), nextPowerOfTwo(rasterExtent.rows))).toInt
+          }
           else if ( experimental && !multiple_polygons_flag && minTiles >= 8) {
             1024
           } else if ( !multiple_polygons_flag && minTiles >= 2) {

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/file/Sentinel2PyramidFactoryTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/file/Sentinel2PyramidFactoryTest.scala
@@ -164,7 +164,7 @@ class Sentinel2PyramidFactoryTest {
         val actualTiffs = baseLayerSpatial.toGeoTiffs(Tags.empty, GeoTiffOptions(DeflateCompression)).collect().toList.map(t => t._2)
 
         // Values where a multiple of 500 before. Now it should take into account the global extent offset:
-        assertEquals(Extent(631800.0, 5056200.0, 759800.0, 5184200.0), actualTiffs.head.extent)
+        assertEquals(Extent(631800.0, 5152200.0, 663800.0, 5184200.0), actualTiffs.head.extent)
         saveRDD(baseLayerSpatial, 1, "tmp/testPixelShift/testPixelShift.tiff")
     }
 

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/file/Sentinel3PyramidFactoryTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/file/Sentinel3PyramidFactoryTest.scala
@@ -1,14 +1,14 @@
 package org.openeo.geotrellis.file
 
 import geotrellis.proj4.{CRS, LatLng}
-import geotrellis.raster.{CellSize, MultibandTile, Raster, ShortUserDefinedNoDataCellType}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.raster.testkit.RasterMatchers
+import geotrellis.raster.{CellSize, MultibandTile, Raster, ShortUserDefinedNoDataCellType}
 import geotrellis.spark._
 import geotrellis.spark.util.SparkUtils
 import geotrellis.vector.Extent
 import org.apache.spark.SparkContext
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -47,6 +47,13 @@ class Sentinel3PyramidFactoryTest extends RasterMatchers {
     MultibandGeoTiff(raster, crs).write(s"/tmp/testTOA_NDVI_${String.join("_", bands)}.tif")
   }
 
+  def extentEquals(e1: Extent, e2: Extent, tolerance: Double = 1e-6): Boolean = {
+    math.abs(e1.xmin - e2.xmin) < tolerance &&
+      math.abs(e1.ymin - e2.ymin) < tolerance &&
+      math.abs(e1.xmax - e2.xmax) < tolerance &&
+      math.abs(e1.ymax - e2.ymax) < tolerance
+  }
+
   @Test
   def compareReferenceImage(): Unit = {
     val referenceGeoTiff = MultibandGeoTiff("/data/projects/OpenEO/automated_test_files/Sentinel3_2020-07-01.tif")
@@ -56,7 +63,8 @@ class Sentinel3PyramidFactoryTest extends RasterMatchers {
     val bandMix = util.Arrays.asList("MIR", "TOA_NDVI", "B2", "tg")
     val (actualRaster, actualCrs) = sentinel3Raster(bandMix)
 
-    assertEqual(referenceRaster, actualRaster)
+    assertEqual(referenceRaster.tile, actualRaster.tile)
+    assertTrue(extentEquals(referenceRaster.extent,actualRaster.extent))
     assertEquals(referenceCrs, actualCrs)
   }
 

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
@@ -61,10 +61,10 @@ class AgEra5FileLayerProviderTest {
 
     assertEquals(27901.130,histogram(0).mean().get,1.0)
     assertEquals(0.247,histogram(1).mean().get,0.01)
-    assertEquals(11413342,histogram(2).mean().get,1.0)
-    assertEquals(1157,histogram(0).totalCount())
-    assertEquals(1224,histogram(1).totalCount())
-    assertEquals(2500,histogram(2).totalCount())
+    assertEquals(11597040,histogram(2).mean().get,1.0)
+    assertEquals(1207,histogram(0).totalCount())
+    assertEquals(1274,histogram(1).totalCount())
+    assertEquals(2550,histogram(2).totalCount())
 
     assertEquals(FloatConstantNoDataCellType, spatialLayer.metadata.cellType)
     assertEquals(LatLng, spatialLayer.metadata.crs)

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/AgEra5FileLayerProviderTest.scala
@@ -59,7 +59,7 @@ class AgEra5FileLayerProviderTest {
 
     val histogram = spatialLayer.histogram()
 
-    assertEquals(27902.167,histogram(0).mean().get,1.0)
+    assertEquals(27901.130,histogram(0).mean().get,1.0)
     assertEquals(0.247,histogram(1).mean().get,0.01)
     assertEquals(11413342,histogram(2).mean().get,1.0)
     assertEquals(1157,histogram(0).totalCount())

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/FileLayerProviderTest.scala
@@ -17,20 +17,20 @@ import geotrellis.spark.util.SparkUtils
 import geotrellis.vector._
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveInputStream}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.{SparkConf, SparkContext}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotSame, assertSame, assertTrue}
-import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api._
+import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.openeo.geotrellis.LayerFixtures.loadFeaturesWithArtifactoryMock
 import org.openeo.geotrellis.TestImplicits._
+import org.openeo.geotrellis._
 import org.openeo.geotrellis.file.{FixedFeaturesOpenSearchClient, PyramidFactory}
 import org.openeo.geotrellis.geotiff._
 import org.openeo.geotrellis.layers.FileLayerProvider.rasterSourceRDD
 import org.openeo.geotrellis.netcdf.{NetCDFOptions, NetCDFRDDWriter}
-import org.openeo.geotrellis._
 import org.openeo.geotrelliscommon.DatacubeSupport._
 import org.openeo.geotrelliscommon.{ConfigurableSpaceTimePartitioner, DataCubeParameters, DatacubeSupport, NoCloudFilterStrategy, SpaceTimeByMonthPartitioner, SparseSpaceTimePartitioner}
 import org.openeo.opensearch.OpenSearchResponses.{CreoFeatureCollection, FeatureCollection, Link}
@@ -353,7 +353,8 @@ class FileLayerProviderTest extends RasterMatchers{
     val expected = size match {
       case 69854 => 512 // 1024 if experimental flag set
       case 1589 => 512
-      case _ => 256
+      case 489 => 256
+      case _ => 128
     }
     assertEquals(expected,scheme.asInstanceOf[FloatingLayoutScheme].tileRows)
 

--- a/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/Sentinel2FileLayerProviderTest.scala
+++ b/openeo-geotrellis/src/test/scala/org/openeo/geotrellis/layers/Sentinel2FileLayerProviderTest.scala
@@ -351,7 +351,7 @@ class Sentinel2FileLayerProviderTest extends RasterMatchers {
     println(SizeEstimator.estimate(localData))
     println((System.currentTimeMillis()-time)/1000)
     println(localData.map(_._1.time).mkString(";"))
-    assertEquals(13,localData.length)
+    assertEquals(43,localData.length)
     assertEquals(4,localData(0)._2.bandCount)
     assertFalse(localData(0)._2.band(0).isNoDataTile)
     assertEquals(ShortUserDefinedNoDataCellType(32767),localData(0)._2.band(1).cellType)


### PR DESCRIPTION
Instead of always using 256x256 pixels, work with a smaller chunk size depending on size in pixels of the global extent.

This reduces memory use, and avoids that users have to specify a very small tilesize themselves when loading low res data.

This helps to fix the well known agera5 upsampling OOM issue in cases where the extent covers only a few agera5 pixels.