### PR TITLE
Bump almalinux8.5-spark-py-openeo:3.5.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ def maven_version            = '3.5.4'
 def node_label               = 'default'
 def wipeout_workspace        = true
 
-def maven_image              = "vito-docker.artifactory.vgt.vito.be/almalinux8.5-spark-py-openeo:3.5.3"
+def maven_image              = "vito-docker.artifactory.vgt.vito.be/almalinux8.5-spark-py-openeo:3.5.6"
 
 
 pipeline {

--- a/docker/tests_dockerfile
+++ b/docker/tests_dockerfile
@@ -1,4 +1,4 @@
-FROM vito-docker.artifactory.vgt.vito.be/almalinux8.5-spark-py-openeo:3.5.3
+FROM vito-docker.artifactory.vgt.vito.be/almalinux8.5-spark-py-openeo:3.5.6
 RUN dnf install -y maven git java-11-openjdk-devel dnf-plugins-core
 RUN dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 RUN dnf install -y docker-ce


### PR DESCRIPTION
I found these `almalinux8.5-spark-py-openeo` image references in this project, and I think they need a bump (latest is now 3.5.6)

ref:
- https://github.com/eu-cdse/openeo-cdse-infra/issues/702
- https://github.com/eu-cdse/openeo-cdse-infra/issues/169
