### PR TITLE
S3proxy support

### DIFF
--- a/openeo-geotrellis/pom.xml
+++ b/openeo-geotrellis/pom.xml
@@ -40,6 +40,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
             <version>0.28.7</version>

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
@@ -35,8 +35,12 @@ class MultiClientRangeReaderProvider extends S3RangeReaderProvider {
     val isCloudFerro = s3Endpoint != null &&
       (s3Endpoint.toLowerCase.contains("cloudferro") || s3Endpoint.toLowerCase.endsWith(".dataspace.copernicus.eu"))
 
+    val proxyClient = CreoS3Utils.getProxyS3Client(s3Uri.getBucket)
+
     val theClient: S3Client =
-      if (isCloudFerro) {
+      if (proxyClient != null) {
+        proxyClient
+      } else if (isCloudFerro) {
 
         val deprecatedBuckets = List("EOCLOUD", "eocloud", "DIAS", "dias")
         if (deprecatedBuckets.contains(s3Uri.getBucket)) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
@@ -35,7 +35,7 @@ class MultiClientRangeReaderProvider extends S3RangeReaderProvider {
     val isCloudFerro = s3Endpoint != null &&
       (s3Endpoint.toLowerCase.contains("cloudferro") || s3Endpoint.toLowerCase.endsWith(".dataspace.copernicus.eu"))
 
-    val proxyClient = CreoS3Utils.getProxyS3Client(s3Uri.getBucket)
+    val proxyClient = CreoS3Utils.getS3Client(s3Uri)
 
     val theClient: S3Client =
       if (proxyClient != null) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/MultiClientRangeReaderProvider.scala
@@ -35,7 +35,7 @@ class MultiClientRangeReaderProvider extends S3RangeReaderProvider {
     val isCloudFerro = s3Endpoint != null &&
       (s3Endpoint.toLowerCase.contains("cloudferro") || s3Endpoint.toLowerCase.endsWith(".dataspace.copernicus.eu"))
 
-    val proxyClient = CreoS3Utils.getS3Client(s3Uri)
+    val proxyClient = CreoS3Utils.getProxyS3Client(s3Uri.getBucket)
 
     val theClient: S3Client =
       if (proxyClient != null) {

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -1,11 +1,12 @@
 package org.openeo.geotrellis.creo
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import geotrellis.store.s3.AmazonS3URI
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
 import org.openeo.geotrelliss3.S3Utils
 import org.slf4j.LoggerFactory
-import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.{AnonymousCredentialsProvider, AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.awscore.retry.conditions.RetryOnErrorCodeCondition
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.retry.RetryPolicy
@@ -15,6 +16,8 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Client, S3Configuration}
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest
 
@@ -27,6 +30,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 object CreoS3Utils {
   private val logger = LoggerFactory.getLogger(getClass)
+  private val objectMapper = new ObjectMapper()
 
   private val cloudFerroRegion: Region = Region.of("RegionOne")
 
@@ -45,6 +49,66 @@ object CreoS3Utils {
       .region(cloudFerroRegion)
       .endpointOverride(URI.create(sys.env("SWIFT_URL")))
       .build();
+  }
+
+  // Return a Client that goes through the S3 proxy if S3 proxy is available for the execution environment.
+  def getProxyS3Client(bucketName: String): S3Client = {
+    val tokenFile = Path.of(sys.env.getOrElse("OPENEO_WEB_IDENTITY_TOKEN_FILE", "/opt/job_config/token"))
+    if (!Files.isRegularFile(tokenFile) || !Files.isReadable(tokenFile)) {
+      logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: web identity token file is not readable: $tokenFile")
+      return null
+    }
+
+    val bucketConfigFile = Path.of(sys.env.getOrElse("OPENEO_BUCKET_CONFIG_FILE", "/opt/job_config/bucket_config.json"))
+    if (!Files.isRegularFile(bucketConfigFile) || !Files.isReadable(bucketConfigFile)) {
+      logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: bucket config file is not readable: $bucketConfigFile")
+      return null
+    }
+
+    val bucketConfig = readProxyBucketConfig(bucketName, bucketConfigFile)
+    if (bucketConfig == null) {
+      return null
+    }
+
+    val stsEndpoint = getRequiredUri("S3PROXY_STS_ENDPOINT_URL")
+    if (stsEndpoint == null) {
+      return null
+    }
+
+    val s3Endpoint = getRequiredUri("S3PROXY_S3_ENDPOINT_URL")
+    if (s3Endpoint == null) {
+      return null
+    }
+
+    try {
+      val region = Region.of(bucketConfig.region)
+      val stsClient = StsClient.builder()
+        .credentialsProvider(AnonymousCredentialsProvider.create())
+        .region(region)
+        .endpointOverride(stsEndpoint)
+        .build()
+
+      // Use the STS-backed variant so the web identity exchange can target a custom endpoint.
+      val credentialsProvider = StsWebIdentityTokenFileCredentialsProvider.builder()
+        .stsClient(stsClient)
+        .roleArn(bucketConfig.roleArn)
+        .roleSessionName(proxyRoleSessionName(bucketName))
+        .webIdentityTokenFile(tokenFile)
+        .build()
+
+      S3Client.builder()
+        .credentialsProvider(credentialsProvider)
+        .serviceConfiguration(S3Configuration.builder().checksumValidationEnabled(false).build())
+        .overrideConfiguration(overrideConfig)
+        .forcePathStyle(true)
+        .region(region)
+        .endpointOverride(s3Endpoint)
+        .build()
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: ${e.getMessage}", e)
+        null
+    }
   }
 
   def getCreoS3Client(region: Region = cloudFerroRegion): S3Client = {
@@ -102,6 +166,66 @@ object CreoS3Utils {
         .retryPolicy(retryPolicy)
         .build()
     overrideConfig
+  }
+
+  private case class ProxyBucketConfig(region: String, roleArn: String)
+
+  private def readProxyBucketConfig(bucketName: String, bucketConfigFile: Path): ProxyBucketConfig = {
+    try {
+      val bucketConfigRoot = objectMapper.readTree(bucketConfigFile.toFile)
+      if (bucketConfigRoot == null || !bucketConfigRoot.isObject) {
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: bucket config file does not contain a JSON object: $bucketConfigFile")
+        return null
+      }
+
+      val bucketNode = bucketConfigRoot.path(bucketName)
+      if (bucketNode.isMissingNode || !bucketNode.isObject) {
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: bucket config file has no object entry for this bucket: $bucketConfigFile")
+        return null
+      }
+
+      val region = Option(bucketNode.path("region").asText(null)).map(_.trim).filter(_.nonEmpty).orNull
+      if (region == null) {
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: bucket config entry has no region: $bucketConfigFile")
+        return null
+      }
+
+      val roleArn = Option(bucketNode.path("role_arn").asText(null)).map(_.trim).filter(_.nonEmpty).orNull
+      if (roleArn == null) {
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: bucket config entry has no role_arn: $bucketConfigFile")
+        return null
+      }
+
+      ProxyBucketConfig(region, roleArn)
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: failed to read bucket config file $bucketConfigFile: ${e.getMessage}", e)
+        null
+    }
+  }
+
+  private def getRequiredUri(envName: String): URI = {
+    val endpointValue = sys.env.get(envName).map(_.trim).filter(_.nonEmpty).orNull
+    if (endpointValue == null) {
+      logger.warn(s"Cannot build proxy S3 client: environment variable $envName is not set.")
+      return null
+    }
+
+    try {
+      URI.create(endpointValue)
+    } catch {
+      case e: IllegalArgumentException =>
+        logger.warn(s"Cannot build proxy S3 client: environment variable $envName does not contain a valid URI: $endpointValue", e)
+        null
+    }
+  }
+
+  private def proxyRoleSessionName(bucketName: String): String = {
+    val podName = sys.env.getOrElse("SPARK_EXECUTOR_POD_NAME", "unknown-sparkappid")
+    val sparkAppId = podName.split("-").slice(0, 2).mkString("-")
+    val executorId = sys.env.getOrElse("SPARK_EXECUTOR_ID", "00")
+
+    s"$sparkAppId-$executorId-$bucketName".take(64)
   }
 
   //noinspection ScalaWeakerAccess

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -24,13 +24,16 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest
 import java.net.URI
 import java.nio.file.{Files, Path}
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
+import scala.compat.java8.FunctionConverters._
 import scala.collection.immutable.Iterable
 import scala.util.control.Breaks.{break, breakable}
 
 object CreoS3Utils {
   private val logger = LoggerFactory.getLogger(getClass)
   private val objectMapper = new ObjectMapper()
+  private val proxyS3ClientCache = new ConcurrentHashMap[String, S3Client]()
 
   private val cloudFerroRegion: Region = Region.of("RegionOne")
 
@@ -52,7 +55,13 @@ object CreoS3Utils {
   }
 
   // Return a Client that goes through the S3 proxy if S3 proxy is available for the execution environment.
+  // Results are cached per bucket name; failures (null) are not cached and will be retried on the next call.
   def getProxyS3Client(bucketName: String): S3Client = {
+    if (bucketName == null || bucketName.isEmpty) return null
+    proxyS3ClientCache.computeIfAbsent(bucketName, (buildProxyS3Client _).asJava)
+  }
+
+  private def buildProxyS3Client(bucketName: String): S3Client = {
     val tokenFile = Path.of(sys.env.getOrElse("OPENEO_WEB_IDENTITY_TOKEN_FILE", "/opt/job_config/token"))
     if (!Files.isRegularFile(tokenFile) || !Files.isReadable(tokenFile)) {
       logger.warn(s"Cannot build proxy S3 client for bucket $bucketName: web identity token file is not readable: $tokenFile")

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -54,9 +54,10 @@ object CreoS3Utils {
       .build();
   }
 
-  // Return a Client that goes through the S3 proxy if S3 proxy is available for the execution environment.
+  // Return a Client that goes through the S3 proxy if S3 proxy is available for the execution environment and
+  // if the job received a bucket configuration.
   // Results are cached per bucket name; failures (null) are not cached and will be retried on the next call.
-  def getProxyS3Client(bucketName: String): S3Client = {
+  private def getProxyS3Client(bucketName: String): S3Client = {
     if (bucketName == null || bucketName.isEmpty) return null
     proxyS3ClientCache.computeIfAbsent(bucketName, (buildProxyS3Client _).asJava)
   }
@@ -120,6 +121,12 @@ object CreoS3Utils {
     }
   }
 
+  def getS3Client(uri: AmazonS3URI): S3Client = {
+    val proxy = getProxyS3Client(uri.getBucket)
+    if (proxy != null) proxy else getCreoS3Client()
+  }
+
+  //Prefer using getS3Client with an S3 URI
   def getCreoS3Client(region: Region = cloudFerroRegion): S3Client = {
     val endpointURI = if (region != cloudFerroRegion) this.getCFEndpoin(region) else URI.create(sys.env("SWIFT_URL"))
     val credProvider = if (region.toString.contains("waw")) credentialsProviderWAW else credentialsProvider

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -57,7 +57,7 @@ object CreoS3Utils {
   // Return a Client that goes through the S3 proxy if S3 proxy is available for the execution environment and
   // if the job received a bucket configuration.
   // Results are cached per bucket name; failures (null) are not cached and will be retried on the next call.
-  private def getProxyS3Client(bucketName: String): S3Client = {
+  def getProxyS3Client(bucketName: String): S3Client = {
     if (bucketName == null || bucketName.isEmpty) return null
     proxyS3ClientCache.computeIfAbsent(bucketName, (buildProxyS3Client _).asJava)
   }

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/creo/CreoS3Utils.scala
@@ -246,7 +246,7 @@ object CreoS3Utils {
 
   //noinspection ScalaWeakerAccess
   def deleteCreoSubFolder(bucket_name: String, subfolder: String): Unit = {
-    val s3Client = getCreoS3Client()
+    val s3Client = getS3Client(new AmazonS3URI(s"s3://$bucket_name"))
     S3Utils.deleteSubFolder(s3Client, bucket_name, subfolder)
   }
 
@@ -296,7 +296,7 @@ object CreoS3Utils {
         .bucket(s3Uri.getBucket)
         .delete(Delete.builder.objects(keys.map(key => ObjectIdentifier.builder.key(key).build).asJavaCollection).build)
         .build
-      getCreoS3Client().deleteObjects(deleteObjectsRequest)
+      getS3Client(s3Uri).deleteObjects(deleteObjectsRequest)
     } else {
       val p = Path.of(path)
       if (Files.isDirectory(p)) {
@@ -314,7 +314,7 @@ object CreoS3Utils {
         .bucket(s3Uri.getBucket)
         .prefix(s3Uri.getKey)
         .build
-      val listObjectsResponse = getCreoS3Client().listObjects(listObjectsRequest)
+      val listObjectsResponse = getS3Client(s3Uri).listObjects(listObjectsRequest)
       listObjectsResponse.contents.asScala.map(o => f"s3://${s3Uri.getBucket}/${o.key}").toSet
     } else {
       Files.list(Path.of(path)).toArray.map(_.toString).toSet
@@ -330,7 +330,7 @@ object CreoS3Utils {
           .bucket(s3Uri.getBucket)
           .key(s3Uri.getKey)
           .build
-        getCreoS3Client().headObject(objectRequest)
+        getS3Client(s3Uri).headObject(objectRequest)
         true
       } catch {
         case _: NoSuchKeyException => false
@@ -350,7 +350,12 @@ object CreoS3Utils {
         .destinationBucket(s3UriDestination.getBucket)
         .destinationKey(s3UriDestination.getKey)
         .build
-      getCreoS3Client().copyObject(copyRequest)
+      val originClient = getS3Client(s3UriOrigin)
+      val destClient = getS3Client(s3UriDestination)
+      if (originClient.serviceClientConfiguration().region() == destClient.serviceClientConfiguration().region() ) {
+        throw new IllegalArgumentException(f"S3->S3 cross region not supported yet ($pathOrigin, $pathDestination)")
+      }
+      originClient.copyObject(copyRequest)
     } else if (!isS3(pathOrigin) && !isS3(pathDestination)) {
       Files.copy(Path.of(pathOrigin), Path.of(pathDestination))
     } else if (!isS3(pathOrigin) && isS3(pathDestination)) {
@@ -419,7 +424,7 @@ object CreoS3Utils {
       .key(s3Uri.getKey)
       .build
 
-    getCreoS3Client().putObject(objectRequest, RequestBody.fromFile(localFile))
+    getS3Client(s3Uri).putObject(objectRequest, RequestBody.fromFile(localFile))
     s3Path
   }
 
@@ -472,7 +477,7 @@ object CreoS3Utils {
         .bucket(s3Uri.getBucket)
         .key(s3Uri.getKey)
         .build
-      val response = getCreoS3Client().getObject(objectRequest)
+      val response = getS3Client(s3Uri).getObject(objectRequest)
       val content = response.readAllBytes()
       new String(content)
     } else {
@@ -489,7 +494,7 @@ object CreoS3Utils {
         .build
       val tempFile = Files.createTempFile("tmp_writeStringToFile", ".txt")
       Files.writeString(tempFile, content)
-      getCreoS3Client().putObject(objectRequest, tempFile)
+      getS3Client(s3Uri).putObject(objectRequest, tempFile)
       Files.delete(tempFile)
     } else {
       Files.writeString(Path.of(path), content)

--- a/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/netcdf/NetCDFRDDWriter.scala
+++ b/openeo-geotrellis/src/main/scala/org/openeo/geotrellis/netcdf/NetCDFRDDWriter.scala
@@ -734,7 +734,7 @@ object NetCDFRDDWriter {
       .key(s3Uri.getKey)
       .build
 
-    CreoS3Utils.getCreoS3Client().putObject(objectRequest, RequestBody.fromFile(Paths.get(localPath)))
+    CreoS3Utils.getS3Client(s3Uri).putObject(objectRequest, RequestBody.fromFile(Paths.get(localPath)))
     correctS3Path
   }
 


### PR DESCRIPTION
Allow configuration of clients against the S3proxy by providing a bucket configuration file.

Since these codes path fallback to the previous client this should have limited impact but it allows:
- Providing access paths without code changes in the future
- toggling s3proxy usage at job level 