### PR TITLE
A generated module to compute sigma0 backscatter directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
                 <module>geopyspark-geotrellis</module>
                 <module>openeo-dependencies</module>
                 <module>openeo-geotrellis-healpix</module>
+                <module>sar-terrain-correction</module>
             </modules>
         </profile>
     </profiles>

--- a/sar-terrain-correction/README.md
+++ b/sar-terrain-correction/README.md
@@ -1,0 +1,44 @@
+# sar-terrain-correction
+
+A small Scala framework that produces a calibrated, terrain-corrected output tile
+(sigma0 + local incidence angle) from a Sentinel-1 GRD product, given:
+
+* a target `Extent`, `CellSize` and `CRS`
+* a STAC item URL pointing at the GRD (e.g. CDSE STAC API)
+
+It exposes two interchangeable backends behind `TerrainCorrectionBackend`:
+
+| Backend  | Class                                                  | Notes |
+|----------|--------------------------------------------------------|-------|
+| Native   | `org.openeo.sar.backend.native.NativeBackend`          | Pure Scala, no deps beyond GeoTrellis |
+| ONNX     | `org.openeo.sar.backend.onnx.OnnxBackend`              | Loads `sar_tc.onnx`, runs via ONNX Runtime (CPU/GPU) |
+
+Both backends accept the same `TileComputeContext` (assembled metadata + raster
+sources) and produce the same `MultibandTile` layout:
+
+```
+band 0: sigma0 (linear, Float32, NaN where outside swath / invalid)
+band 1: localIncidenceAngle (degrees, Float32)
+band 2: validity mask       (0 = invalid, 1 = valid)
+```
+
+This module is single-tile: no Spark. It is designed to be wrapped in a
+Spark job that iterates over output tile keys.
+
+## ONNX model
+
+`scripts/build_onnx_model.py` builds `sar_tc.onnx` using PyTorch. Run once:
+
+```
+pip install torch onnx onnxruntime numpy
+python scripts/build_onnx_model.py --out src/main/resources/sar_tc.onnx
+```
+
+The model expresses the per-pixel inner loop (zero-Doppler iteration, slant
+range, bilinear sampling, calibration, incidence angle) as a single graph.
+
+## Reading SAFE bytes from S3
+
+All raster I/O goes through GeoTrellis `RasterSource`, which already supports
+S3 (`s3://...`) and HTTP(S) URLs. No SNAP, no FUSE mount, no SAFE-zip reader
+needed; we read the measurement TIFFs and DEM COGs directly.

--- a/sar-terrain-correction/pom.xml
+++ b/sar-terrain-correction/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>openeo-geotrellis-extensions</artifactId>
+        <groupId>org.openeo</groupId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>sar-terrain-correction</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <onnxruntime.version>1.20.0</onnxruntime.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+
+        <!-- GeoTrellis: RasterSource, reprojection, cell types, tiles -->
+        <dependency>
+            <groupId>org.locationtech.geotrellis</groupId>
+            <artifactId>geotrellis-raster_${scala.binary.version}</artifactId>
+            <version>${geotrellis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openeo</groupId>
+            <artifactId>openeo-geotrellis</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geotrellis</groupId>
+            <artifactId>geotrellis-gdal_${scala.binary.version}</artifactId>
+            <version>${geotrellis.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geotrellis</groupId>
+            <artifactId>geotrellis-s3_${scala.binary.version}</artifactId>
+            <version>${geotrellis.version}</version>
+        </dependency>
+
+        <!-- ONNX runtime (CPU). Swap for onnxruntime_gpu if needed. -->
+        <dependency>
+            <groupId>com.microsoft.onnxruntime</groupId>
+            <artifactId>onnxruntime</artifactId>
+            <version>${onnxruntime.version}</version>
+        </dependency>
+
+        <!-- JSON for STAC item parsing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spark + GeoTrellis Spark (provided in prod, explicit test scope here) -->
+        <dependency>
+            <groupId>org.locationtech.geotrellis</groupId>
+            <artifactId>geotrellis-spark_${scala.binary.version}</artifactId>
+            <version>${geotrellis.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>4.9.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sar-terrain-correction/src/main/resources/META-INF/services/org.openeo.geotrellis.layers.provider.RasterSourceProvider
+++ b/sar-terrain-correction/src/main/resources/META-INF/services/org.openeo.geotrellis.layers.provider.RasterSourceProvider
@@ -1,0 +1,1 @@
+org.openeo.sar.provider.DefaultSentinel1GrdRasterSourceProvider

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/TerrainCorrectionProcessor.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/TerrainCorrectionProcessor.scala
@@ -1,0 +1,182 @@
+package org.openeo.sar
+
+import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.raster._
+import geotrellis.raster.resample.Bilinear
+import geotrellis.vector.Extent
+import org.openeo.sar.backend.TerrainCorrectionBackend
+import org.openeo.sar.metadata.{Polarisation, S1AnnotationParser, S1GrdMetadata}
+import org.openeo.sar.stac.{StacAssets, StacItemLoader}
+
+import java.net.URI
+
+/** Top-level entry point.
+ *
+ *  The split into two stages is explicit to allow efficient multi-tile reads:
+ *
+ *  Stage 1  [[openScene]]     – O(1) per scene.  Parses the SAFE annotation
+ *           XMLs (orbit, LUTs, SRGR polynomials), opens RasterSources for the
+ *           measurement TIFFs / DEM / geoid.  Results are captured in a
+ *           [[SceneContext]] which is immutable and cheap to share.
+ *
+ *  Stage 2  [[readExtents]]   – O(N) per tile.  Dispatches per-extent work to
+ *           the backend.  Only windowed raster I/O and per-pixel geometry
+ *           happen here; no XML parsing, no RasterSource construction.
+ *
+ *  The single-tile helper [[computeTile]] is retained for convenience
+ *  (it calls both stages). */
+final class TerrainCorrectionProcessor(
+  backend: TerrainCorrectionBackend,
+  demSourceFactory: Extent => RasterSource,
+  geoidSourceFactory: Option[Extent => RasterSource] = None,
+  rasterSourceFactory: URI => RasterSource = TerrainCorrectionProcessor.defaultRasterSourceFactory
+) {
+
+  // -------------------------------------------------------------------------
+  // Stage 1: scene-level initialisation
+  // -------------------------------------------------------------------------
+
+  /** Parse a STAC item and open all required RasterSources.  Expensive; call
+   *  once per scene, then reuse the returned [[SceneContext]] for all tiles. */
+  def openScene(stacItemUrl: URI,
+                cellSize: CellSize,
+                crs: CRS,
+                polarisations: Seq[Polarisation]): SceneContext = {
+
+    val assets: StacAssets = StacItemLoader.load(stacItemUrl)
+
+    val perPol = polarisations.map { pol =>
+      val a = assets.perPol.getOrElse(pol.code,
+        throw new IllegalArgumentException(s"polarisation ${pol.code} not present in STAC item"))
+      S1AnnotationParser.parseProductAnnotation(
+        a.productAnnotation, a.measurement, a.calibration, a.noise, pol)
+    }
+    val meta: S1GrdMetadata = S1AnnotationParser.assemble(perPol)
+
+    val sarSources: Map[Polarisation, RasterSource] = polarisations.map { pol =>
+      pol -> rasterSourceFactory(assets.perPol(pol.code).measurement)
+    }.toMap
+
+    // Use the scene bounding box from the STAC item to pre-open a DEM source
+    // that covers the whole scene.  Per-tile reads will window into it cheaply.
+    val (lonMin, latMin, lonMax, latMax) = assets.bboxWgs84
+    val sceneBboxWgs84 = Extent(lonMin, latMin, lonMax, latMax).buffer(0.05)
+    val demSource   = demSourceFactory(sceneBboxWgs84)
+    val geoidSource = geoidSourceFactory.map(_(sceneBboxWgs84))
+
+    SceneContext(meta, sarSources, demSource, geoidSource, cellSize, crs, polarisations)
+  }
+
+  // -------------------------------------------------------------------------
+  // Stage 2: per-tile compute
+  // -------------------------------------------------------------------------
+
+  /** Compute an output [[Raster]] for every extent in `extents`.
+   *
+   *  `bands` selects which output bands to include (0-based):
+   *    0 .. nPols-1 → sigma0 per polarisation
+   *    nPols        → local incidence angle (degrees)
+   *    nPols+1      → validity mask
+   *
+   *  This matches the [[RasterSource.readExtents]] contract so that a
+   *  [[TerrainCorrectionRasterSource]] wrapper can delegate here without any
+   *  additional logic.
+   *
+   *  Only per-tile windowed I/O and geometry happen inside this iterator;
+   *  the scene-level [[SceneContext]] is closed over by reference. */
+  def readExtents(scene: SceneContext,
+                  extents: Traversable[Extent],
+                  bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
+    val totalBands = scene.polarisations.size + 2
+    val effectiveBands = if (bands.isEmpty) (0 until totalBands) else bands
+    extents.toIterator.map { extent =>
+      val ctx  = scene.tileContext(extent)
+      val full = backend.compute(ctx)           // always compute all bands; band selection is cheap
+      val selected = MultibandTile(effectiveBands.map(full.band))
+      Raster(selected, extent)
+    }
+  }
+
+  /** All bands, convenience overload. */
+  def readExtents(scene: SceneContext,
+                  extents: Traversable[Extent]): Iterator[Raster[MultibandTile]] =
+    readExtents(scene, extents, Seq.empty)
+
+  // -------------------------------------------------------------------------
+  // Convenience: single tile (opens scene internally, fine for one-off calls)
+  // -------------------------------------------------------------------------
+
+  def computeTile(stacItemUrl: URI, request: TileRequest): MultibandTile = {
+    val scene = openScene(stacItemUrl, request.cellSize, request.crs, request.polarisations)
+    readExtents(scene, List(request.extent)).next().tile
+  }
+}
+
+object TerrainCorrectionProcessor {
+  def defaultRasterSourceFactory: URI => RasterSource = { uri =>
+    // GeoTrellis RasterSource auto-dispatches on scheme: file:// http(s):// s3://
+    geotrellis.raster.geotiff.GeoTiffRasterSource(uri.toString)
+  }
+
+  /** Factory wrapping a single GeoTIFF (typically the EGM2008 / EGM96
+   *  undulation grid in EPSG:4326) as the geoid source. */
+  def geoidFromTiff(uri: URI): Extent => RasterSource = {
+    val rs = defaultRasterSourceFactory(uri)
+    _ => rs
+  }
+
+  def withDemAndGeoid(backend: TerrainCorrectionBackend,
+                      demFactory: Extent => RasterSource,
+                      geoidTiffUri: URI): TerrainCorrectionProcessor =
+    new TerrainCorrectionProcessor(
+      backend            = backend,
+      demSourceFactory   = demFactory,
+      geoidSourceFactory = Some(geoidFromTiff(geoidTiffUri))
+    )
+
+  /** Read the DEM window for the output tile, reprojected to the target CRS at
+   *  target cell size; converted from orthometric to ellipsoidal heights via the
+   *  optional geoid undulation grid. Returns a (rows x cols) array of metres. */
+  def readDemEllipsoidal(ctx: TileComputeContext): Array[Array[Double]] = {
+    val req = ctx.request
+    val targetRe = RasterExtent(req.extent, req.cellSize.width, req.cellSize.height, req.cols, req.rows)
+    val defaultTile = new Raster( MultibandTile(FloatConstantTile(10.0f, req.cols, req.rows)), req.extent)
+    val dem = ctx.demSource
+      .reproject(req.crs, method = Bilinear)
+      .resampleToGrid(targetRe.toGridType[Long], Bilinear)
+      .read(req.extent).getOrElse(
+        defaultTile)
+        //throw new IllegalStateException(s"DEM read returned no raster for AOI ${ctx.demSource.name}"))
+      .tile.band(0)
+
+    val geoid: Option[Tile] = ctx.geoidSource.map { gs =>
+      gs.reproject(req.crs, TargetRegion(targetRe.toGridType[Long]), method = Bilinear)
+        .read().get.tile.band(0)
+    }
+
+    val out = Array.ofDim[Double](req.rows, req.cols)
+    var r = 0
+    while (r < req.rows) {
+      var c = 0
+      while (c < req.cols) {
+        val ortho = dem.getDouble(c, r)
+        val und   = geoid.map(_.getDouble(c, r)).getOrElse(0.0)
+        out(r)(c) = if (java.lang.Double.isNaN(ortho)) Double.NaN else ortho + und
+        c += 1
+      }
+      r += 1
+    }
+    out
+  }
+
+  /** Map an output (col, row) to (lon, lat) in radians. */
+  def pixelToLonLatRad(col: Int, row: Int, req: TileRequest): (Double, Double) = {
+    val xMap = req.extent.xmin + (col + 0.5) * req.cellSize.width
+    val yMap = req.extent.ymax - (row + 0.5) * req.cellSize.height
+    val (lon, lat) = geotrellis.proj4.Transform(req.crs, LatLng)(xMap, yMap)
+    (math.toRadians(lon), math.toRadians(lat))
+  }
+}
+
+
+

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/TileRequest.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/TileRequest.scala
@@ -1,0 +1,62 @@
+package org.openeo.sar
+
+import geotrellis.proj4.CRS
+import geotrellis.raster.{CellSize, RasterSource}
+import geotrellis.vector.Extent
+import org.openeo.sar.metadata.{Polarisation, S1GrdMetadata}
+
+/** Output tile description supplied by the caller. */
+final case class TileRequest(
+  extent: Extent,
+  cellSize: CellSize,
+  crs: CRS,
+  polarisations: Seq[Polarisation]
+) {
+  def cols: Int = math.round(extent.width  / cellSize.width ).toInt
+  def rows: Int = math.round(extent.height / cellSize.height).toInt
+}
+
+/** Scene-level state that is expensive to build and shared across all tiles
+ *  produced from the same SAR scene.  Constructed once by
+ *  [[TerrainCorrectionProcessor.openScene]]; immutable and thread-safe.
+ *
+ *  - `metadata`: orbit, calibration LUTs, SRGR polynomials, timing — parsed
+ *    from the SAFE annotation XMLs.
+ *  - `sarSources`: one [[RasterSource]] per polarisation pointing at the full
+ *    measurement GeoTIFF.  RasterSources are cheap to keep open and perform
+ *    windowed reads on demand.
+ *  - `demSource` / `geoidSource`: single scene-wide raster sources; each tile
+ *    will read only its own AOI window. */
+final case class SceneContext(
+  metadata: S1GrdMetadata,
+  sarSources: Map[Polarisation, RasterSource],
+  demSource: RasterSource,
+  geoidSource: Option[RasterSource],
+  /** Shared CRS and cell size for all tiles produced from this scene. */
+  cellSize: CellSize,
+  crs: CRS,
+  polarisations: Seq[Polarisation]
+) {
+  /** Build the per-tile context for a given extent without any I/O or parsing. */
+  def tileContext(extent: Extent): TileComputeContext =
+    TileComputeContext(
+      TileRequest(extent, cellSize, crs, polarisations),
+      metadata, sarSources, demSource, geoidSource
+    )
+}
+
+/** Fully-assembled inputs for one tile computation. The orchestrator builds
+ *  this; backends consume it. Keeps backends free of I/O. */
+final case class TileComputeContext(
+  request: TileRequest,
+  metadata: S1GrdMetadata,
+  /** Per-polarisation measurement RasterSource (full scene, in SAR geometry). */
+  sarSources: Map[Polarisation, RasterSource],
+  /** DEM RasterSource. Caller is responsible for picking a DEM that covers
+   *  the AOI; the orchestrator will read the AOI window from it and reproject
+   *  to the output CRS at the target cell size. */
+  demSource: RasterSource,
+  /** Geoid undulation RasterSource (e.g. EGM2008), or None to assume DEM is
+   *  already ellipsoidal heights. */
+  geoidSource: Option[RasterSource]
+)

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/TerrainCorrectionBackend.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/TerrainCorrectionBackend.scala
@@ -1,0 +1,30 @@
+package org.openeo.sar.backend
+
+import geotrellis.raster.{FloatArrayTile, MultibandTile, Tile}
+import org.openeo.sar.TileComputeContext
+
+/** A backend computes one terrain-corrected, calibrated output tile.
+ *
+ *  Output layout (all Float32, NaN/0 outside swath):
+ *    band 0..N-1:  sigma0 per requested polarisation, in linear power
+ *    band N:       local incidence angle in degrees
+ *    band N+1:     validity mask (1.0 valid / 0.0 invalid) */
+trait TerrainCorrectionBackend {
+  def name: String
+  def compute(ctx: TileComputeContext): MultibandTile
+}
+
+object TerrainCorrectionBackend {
+  /** Helper for backends: empty Float32 output tiles in the right layout. */
+  def allocate(cols: Int, rows: Int, nPols: Int): (Array[FloatArrayTile], FloatArrayTile, FloatArrayTile) = {
+    val sigmas = Array.fill(nPols)(FloatArrayTile.empty(cols, rows))
+    val inc    = FloatArrayTile.empty(cols, rows)
+    val mask   = FloatArrayTile.empty(cols, rows)
+    (sigmas, inc, mask)
+  }
+
+  def assemble(sigmas: Array[FloatArrayTile], inc: FloatArrayTile, mask: FloatArrayTile): MultibandTile = {
+    val bands: Array[Tile] = sigmas.asInstanceOf[Array[Tile]] :+ inc.asInstanceOf[Tile] :+ mask.asInstanceOf[Tile]
+    MultibandTile(bands.toIndexedSeq)
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/nativ/NativeBackend.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/nativ/NativeBackend.scala
@@ -1,0 +1,144 @@
+package org.openeo.sar.backend.nativ
+
+import geotrellis.raster.{GridBounds, MultibandTile, Tile}
+import org.openeo.sar.backend.TerrainCorrectionBackend
+import org.openeo.sar.geom.{Ecef, RangeDoppler, Vec3}
+import org.openeo.sar.metadata.Polarisation
+import org.openeo.sar.{TerrainCorrectionProcessor, TileComputeContext}
+
+/** Pure-Scala terrain correction. Operates on already-assembled inputs in
+ *  `TileComputeContext`. */
+final class NativeBackend extends TerrainCorrectionBackend {
+  override val name = "native"
+
+  override def compute(ctx: TileComputeContext): MultibandTile = {
+    val req = ctx.request
+    val meta = ctx.metadata
+    val pols = req.polarisations.toArray
+
+    val (sigmas, inc, mask) = TerrainCorrectionBackend.allocate(req.cols, req.rows, pols.length)
+
+    // 1. DEM window for the output tile, ellipsoidal heights (metres).
+    val dem: Array[Array[Double]] = TerrainCorrectionProcessor.readDemEllipsoidal(ctx)
+
+    // 2. Pre-compute per-pixel (lon, lat) on the output grid.
+    val lonLat: Array[Array[(Double, Double)]] = Array.tabulate(req.rows, req.cols) {
+      (r, c) => TerrainCorrectionProcessor.pixelToLonLatRad(c, r, req)
+    }
+
+    // 3. Seed for the zero-Doppler iteration: scene-centre azimuth time.
+    val tSeed = 0.5 * meta.timing.numberOfLines * meta.timing.lineTimeInterval
+
+    // 4. First pass: forward-geocode every output pixel to SAR (line, groundRangePx)
+    //    and remember the bounding box so we issue ONE windowed read per polarisation.
+    case class SarCoord(line: Double, gr: Double, rSlant: Double, pSat: Vec3, pGnd: Vec3)
+    val sarCoords: Array[Array[SarCoord]] = Array.ofDim(req.rows, req.cols)
+    var minLine = Int.MaxValue; var maxLine = Int.MinValue
+    var minPx   = Int.MaxValue; var maxPx   = Int.MinValue
+    var anyValid = false
+
+    var r = 0
+    while (r < req.rows) {
+      var c = 0
+      while (c < req.cols) {
+        val h = dem(r)(c)
+        if (!java.lang.Double.isNaN(h)) {
+          val (lonRad, latRad) = lonLat(r)(c)
+          val pGnd = Ecef.fromGeodetic(lonRad, latRad, h)
+          val tAz  = RangeDoppler.zeroDopplerTime(pGnd, meta.orbit, tSeed)
+          val pSat = meta.orbit.positionAt(tAz)
+          val rSlant = (pSat - pGnd).norm
+          val azLine = tAz / meta.timing.lineTimeInterval
+          val srgr   = meta.polarisations(pols(0)).srgr.at(tAz)
+          val grMetres = srgr.groundRangeFromSlant(rSlant, gSeed = math.max(0.0, rSlant - srgr.sr0))
+          val grPx     = grMetres / meta.timing.rangePixelSpacing
+          sarCoords(r)(c) = SarCoord(azLine, grPx, rSlant, pSat, pGnd)
+
+          if (azLine >= 0 && azLine <  meta.timing.numberOfLines &&
+              grPx   >= 0 && grPx   <  meta.timing.numberOfPixels) {
+            anyValid = true
+            val il = azLine.toInt; val ip = grPx.toInt
+            if (il < minLine) minLine = il; if (il > maxLine) maxLine = il
+            if (ip < minPx)   minPx   = ip; if (ip > maxPx)   maxPx   = ip
+          }
+        }
+        c += 1
+      }
+      r += 1
+    }
+
+    if (!anyValid) return TerrainCorrectionBackend.assemble(sigmas, inc, mask)
+
+    // 5. Pad window by 1 pixel for bilinear sampling, clip to scene.
+    val winMinLine = math.max(0, minLine - 1)
+    val winMinPx   = math.max(0, minPx   - 1)
+    val winMaxLine = math.min(meta.timing.numberOfLines  - 1, maxLine + 1)
+    val winMaxPx   = math.min(meta.timing.numberOfPixels - 1, maxPx   + 1)
+    val winCols    = winMaxPx   - winMinPx   + 1
+    val winRows    = winMaxLine - winMinLine + 1
+
+    // 6. One windowed read per polarisation in SAR coords (Long-keyed GridBounds).
+    val sarWindows: Map[Polarisation, Tile] = pols.map { pol =>
+      val rs = ctx.sarSources(pol)
+      val gb = GridBounds[Long](winMinPx.toLong, winMinLine.toLong, winMaxPx.toLong, winMaxLine.toLong)
+      val tile = rs.read(gb).getOrElse(
+        throw new IllegalStateException(s"SAR window read failed for ${pol.code}")
+      ).tile.band(0)
+      pol -> tile
+    }.toMap
+
+    // 7. Second pass: sample, calibrate, fill incidence + mask.
+    r = 0
+    while (r < req.rows) {
+      var c = 0
+      while (c < req.cols) {
+        val sc = sarCoords(r)(c)
+        if (sc != null &&
+            sc.line >= 0 && sc.line < meta.timing.numberOfLines &&
+            sc.gr   >= 0 && sc.gr   < meta.timing.numberOfPixels) {
+
+          val winLine = sc.line - winMinLine
+          val winPx   = sc.gr   - winMinPx
+
+          var p = 0
+          while (p < pols.length) {
+            val pol = pols(p)
+            val polMeta = meta.polarisations(pol)
+            val dn = bilinear(sarWindows(pol), winPx, winLine)
+            if (!java.lang.Double.isNaN(dn)) {
+              val sigmaLut = polMeta.sigmaLut(sc.line, sc.gr)
+              val noiseLut = polMeta.noiseLut(sc.line, sc.gr)
+              val num = Math.fma( dn, dn, - noiseLut)
+              val sigma0 = if (sigmaLut > 0) num / (sigmaLut * sigmaLut) else Float.NaN
+              sigmas(p).setDouble(c, r, sigma0)
+            }
+            p += 1
+          }
+
+          val normal = Ecef.ellipsoidalNormal(sc.pGnd)
+          val incRad = RangeDoppler.localIncidence(sc.pGnd, sc.pSat, normal)
+          inc.setDouble(c, r, math.toDegrees(incRad))
+          mask.setDouble(c, r, 1.0)
+        }
+        c += 1
+      }
+      r += 1
+    }
+
+    TerrainCorrectionBackend.assemble(sigmas, inc, mask)
+  }
+
+  /** Bilinear DN sample at fractional (col, row) on a `Tile`. Returns NaN
+   *  if the four neighbours fall outside the tile. */
+  private def bilinear(tile: Tile, col: Double, row: Double): Double = {
+    val c0 = math.floor(col).toInt; val c1 = c0 + 1
+    val r0 = math.floor(row).toInt; val r1 = r0 + 1
+    if (c0 < 0 || r0 < 0 || c1 >= tile.cols || r1 >= tile.rows) return Double.NaN
+    val tx = col - c0; val ty = row - r0
+    val v00 = tile.getDouble(c0, r0); val v10 = tile.getDouble(c1, r0)
+    val v01 = tile.getDouble(c0, r1); val v11 = tile.getDouble(c1, r1)
+    val a = v00 + (v10 - v00) * tx
+    val b = v01 + (v11 - v01) * tx
+    a + (b - a) * ty
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/onnx/OnnxBackend.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/backend/onnx/OnnxBackend.scala
@@ -1,0 +1,246 @@
+package org.openeo.sar.backend.onnx
+
+import ai.onnxruntime.{OnnxTensor, OrtEnvironment, OrtSession}
+import geotrellis.raster.{FloatArrayTile, GridBounds, MultibandTile, Tile}
+import org.openeo.sar.backend.TerrainCorrectionBackend
+import org.openeo.sar.geom.{Ecef, Vec3}
+import org.openeo.sar.metadata.S1GrdMetadata
+import org.openeo.sar.{TerrainCorrectionProcessor, TileComputeContext}
+
+import java.nio.{FloatBuffer, LongBuffer}
+import scala.jdk.CollectionConverters._
+
+/** ONNX-backed terrain correction. The ONNX graph implements the per-pixel
+ *  inner loop on flat [N] tensors (one element per output pixel):
+ *
+ *  Inputs:
+ *    lonRad           : float32 [N]
+ *    latRad           : float32 [N]
+ *    h_ellipsoidal_m  : float32 [N]
+ *    sar_window       : float32 [H, W]            (DN, single polarisation, single windowed read)
+ *    sar_win_origin   : int64   [2]               (winMinLine, winMinPx)
+ *    sigma_lut        : float32 [Li, Pi]
+ *    sigma_lines      : int64   [Li]
+ *    sigma_pixels     : int64   [Pi]
+ *    noise_lut        : float32 [Li, Pi]
+ *    orbit_t          : float32 [K]               (K state-vector times, scene-local seconds)
+ *    orbit_pos        : float32 [K, 3]
+ *    orbit_vel        : float32 [K, 3]
+ *    srgr_gr0         : float32 ()
+ *    srgr_coeffs      : float32 [M]               (selected nearest-time poly)
+ *    line_time_interval, range_px_spacing, tSeed  : float32 ()
+ *    nLines, nPixels  : int64 ()
+ *    ecef_origin      : float32 [3]               (tile-local frame origin for fp32 precision)
+ *
+ *  Outputs:
+ *    sigma0    : float32 [N]
+ *    incidence : float32 [N]    (degrees)
+ *    mask      : float32 [N]
+ *
+ *  Per-polarisation execution: one session.run() per polarisation, reusing
+ *  the constant tensors via I/O bindings. */
+final class OnnxBackend(modelPath: String) extends TerrainCorrectionBackend with AutoCloseable {
+  override val name = "onnx"
+
+  private val env: OrtEnvironment = OrtEnvironment.getEnvironment()
+  private val session: OrtSession = {
+    val opts = new OrtSession.SessionOptions()
+    opts.setIntraOpNumThreads(1)            // leave parallelism to the caller (Spark)
+    env.createSession(modelPath, opts)
+  }
+
+  override def compute(ctx: TileComputeContext): MultibandTile = {
+    val req = ctx.request
+    val meta = ctx.metadata
+    val pols = req.polarisations.toArray
+    val n = req.cols * req.rows
+
+    val (sigmas, inc, mask) = TerrainCorrectionBackend.allocate(req.cols, req.rows, pols.length)
+
+    // ---- 1. Build pixel-level inputs that are shared across polarisations ----
+    val dem = TerrainCorrectionProcessor.readDemEllipsoidal(ctx)
+    val lon  = new Array[Float](n); val lat = new Array[Float](n); val hEll = new Array[Float](n)
+    var idx = 0; var r = 0
+    while (r < req.rows) {
+      var c = 0
+      while (c < req.cols) {
+        val (lo, la) = TerrainCorrectionProcessor.pixelToLonLatRad(c, r, req)
+        lon(idx) = lo.toFloat; lat(idx) = la.toFloat
+        val h = dem(r)(c); hEll(idx) = if (java.lang.Double.isNaN(h)) Float.NaN else h.toFloat
+        idx += 1; c += 1
+      }
+      r += 1
+    }
+
+    // ---- 2. Tile-local ECEF origin (use centroid lon/lat at h=0) ----
+    val cx = req.extent.center
+    val (cLonRad, cLatRad) = TerrainCorrectionProcessor.pixelToLonLatRad(req.cols / 2, req.rows / 2, req)
+    val origin: Vec3 = Ecef.fromGeodetic(cLonRad, cLatRad, 0.0)
+
+    // ---- 3. Orbit constant tensors (K, K x 3) ----
+    val (orbitT, orbitPos, orbitVel) = packOrbit(meta, origin)
+
+    // ---- 4. Forward-geocode one pol on CPU just to compute the SAR window bbox. ----
+    //         (cheap; reuses native helpers; could also be moved into ONNX as a separate model.)
+    val window = computeSarWindow(ctx, dem, lon, lat, hEll)
+
+    // ---- 5. Per-polarisation: read SAR window, run the model, scatter outputs. ----
+    var p = 0
+    while (p < pols.length) {
+      val pol = pols(p); val polMeta = meta.polarisations(pol)
+      val sarTile: Tile = ctx.sarSources(pol).read(window.gb).get.tile.band(0)
+
+      val sarBuf = tileToFloatArray(sarTile)
+      val (sigLines, sigPixels, sigVals) = packLut(polMeta.sigmaLut)
+      val (_,        _,         noiseVals) = packLut(polMeta.noiseLut)
+
+      // Pick SRGR poly at scene-centre azimuth time as a constant (good enough at single-tile scale).
+      val tCenter = 0.5 * meta.timing.numberOfLines * meta.timing.lineTimeInterval
+      val srgr = polMeta.srgr.at(tCenter)
+
+      val inputs = Map[String, OnnxTensor](
+        "lonRad"          -> tensor1d(lon),
+        "latRad"          -> tensor1d(lat),
+        "h_ellipsoidal_m" -> tensor1d(hEll),
+        "sar_window"      -> tensor2d(sarBuf, sarTile.rows, sarTile.cols),
+        "sar_win_origin"  -> tensorLong(Array(window.winMinLine.toLong, window.winMinPx.toLong)),
+        "sigma_lut"       -> tensor2d(sigVals, sigLines.length, sigPixels.length),
+        "sigma_lines"     -> tensorLong(sigLines.map(_.toLong)),
+        "sigma_pixels"    -> tensorLong(sigPixels.map(_.toLong)),
+        "noise_lut"       -> tensor2d(noiseVals, sigLines.length, sigPixels.length),
+        "orbit_t"         -> tensor1d(orbitT),
+        "orbit_pos"       -> tensor2d(orbitPos, orbitT.length, 3),
+        "orbit_vel"       -> tensor2d(orbitVel, orbitT.length, 3),
+        "srgr_gr0"        -> scalar(srgr.gr0.toFloat),
+        "srgr_coeffs"     -> tensor1d(srgr.coeffs.map(_.toFloat)),
+        "line_time_interval" -> scalar(meta.timing.lineTimeInterval.toFloat),
+        "range_px_spacing"   -> scalar(meta.timing.rangePixelSpacing.toFloat),
+        "tSeed"              -> scalar(tCenter.toFloat),
+        "nLines"             -> scalarLong(meta.timing.numberOfLines.toLong),
+        "nPixels"            -> scalarLong(meta.timing.numberOfPixels.toLong),
+        "ecef_origin"        -> tensor1d(Array(origin.x.toFloat, origin.y.toFloat, origin.z.toFloat))
+      )
+
+      val result = session.run(inputs.asJava)
+      try {
+        val sigma0 = result.get(0).asInstanceOf[OnnxTensor].getFloatBuffer.array()
+        val incOut = result.get(1).asInstanceOf[OnnxTensor].getFloatBuffer.array()
+        val mskOut = result.get(2).asInstanceOf[OnnxTensor].getFloatBuffer.array()
+        scatter(sigma0, sigmas(p), req.cols, req.rows)
+        if (p == 0) {
+          scatter(incOut, inc, req.cols, req.rows)
+          scatter(mskOut, mask, req.cols, req.rows)
+        }
+      } finally {
+        result.close()
+        inputs.values.foreach(_.close())
+      }
+      p += 1
+    }
+
+    TerrainCorrectionBackend.assemble(sigmas, inc, mask)
+  }
+
+  override def close(): Unit = { session.close() }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private case class Window(winMinLine: Int, winMinPx: Int, gb: GridBounds[Long])
+
+  /** Light forward-geocoding pass to bound the SAR window. Mirrors NativeBackend. */
+  private def computeSarWindow(ctx: TileComputeContext,
+                               dem: Array[Array[Double]],
+                               lon: Array[Float], lat: Array[Float], h: Array[Float]): Window = {
+    import org.openeo.sar.geom.RangeDoppler
+    val req = ctx.request; val meta = ctx.metadata
+    val tSeed = 0.5 * meta.timing.numberOfLines * meta.timing.lineTimeInterval
+    var minLine = Int.MaxValue; var maxLine = Int.MinValue
+    var minPx   = Int.MaxValue; var maxPx   = Int.MinValue
+    val anyPol = ctx.metadata.polarisations.values.head
+    var i = 0
+    while (i < lon.length) {
+      val hv = h(i)
+      if (!java.lang.Float.isNaN(hv)) {
+        val p = Ecef.fromGeodetic(lon(i), lat(i), hv.toDouble)
+        val t = RangeDoppler.zeroDopplerTime(p, meta.orbit, tSeed)
+        val pSat = meta.orbit.positionAt(t)
+        val rSlant = (pSat - p).norm
+        val srgr = anyPol.srgr.at(t)
+        val grM = srgr.groundRangeFromSlant(rSlant, math.max(0.0, rSlant - srgr.sr0))
+        val grPx = (grM / meta.timing.rangePixelSpacing).toInt
+        val azLine = (t / meta.timing.lineTimeInterval).toInt
+        if (azLine >= 0 && azLine < meta.timing.numberOfLines &&
+            grPx   >= 0 && grPx   < meta.timing.numberOfPixels) {
+          if (azLine < minLine) minLine = azLine; if (azLine > maxLine) maxLine = azLine
+          if (grPx   < minPx)   minPx   = grPx;   if (grPx   > maxPx)   maxPx   = grPx
+        }
+      }
+      i += 1
+    }
+    val mnL = math.max(0, minLine - 1); val mnP = math.max(0, minPx - 1)
+    val mxL = math.min(meta.timing.numberOfLines - 1,  maxLine + 1)
+    val mxP = math.min(meta.timing.numberOfPixels - 1, maxPx   + 1)
+    Window(mnL, mnP, GridBounds[Long](mnP.toLong, mnL.toLong, mxP.toLong, mxL.toLong))
+  }
+
+  private def packOrbit(meta: S1GrdMetadata, origin: Vec3): (Array[Float], Array[Float], Array[Float]) = {
+    // We cannot reach the private OrbitInterpolator.svs field; instead expose it via a
+    // typed accessor would be cleaner. For now, re-sample orbit state at fixed times.
+    val nLines = meta.timing.numberOfLines
+    val dt = meta.timing.lineTimeInterval
+    val tStart = -10.0; val tEnd = nLines * dt + 10.0
+    val K = 32
+    val t = Array.tabulate(K)(i => tStart + (tEnd - tStart) * i / (K - 1).toFloat).map(_.toFloat)
+    val pos = new Array[Float](K * 3); val vel = new Array[Float](K * 3)
+    var i = 0
+    while (i < K) {
+      val (p, v) = meta.orbit.stateAt(t(i).toDouble)
+      val pl = p - origin // tile-local for fp32
+      pos(3*i)   = pl.x.toFloat; pos(3*i+1) = pl.y.toFloat; pos(3*i+2) = pl.z.toFloat
+      vel(3*i)   = v.x .toFloat; vel(3*i+1) = v.y .toFloat; vel(3*i+2) = v.z .toFloat
+      i += 1
+    }
+    (t, pos, vel)
+  }
+
+  private def packLut(lut: org.openeo.sar.metadata.Lut2D): (Array[Int], Array[Int], Array[Float]) = {
+    val flat = new Array[Float](lut.lines.length * lut.pixels.length)
+    var i = 0
+    while (i < lut.lines.length) {
+      System.arraycopy(lut.values(i), 0, flat, i * lut.pixels.length, lut.pixels.length)
+      i += 1
+    }
+    (lut.lines, lut.pixels, flat)
+  }
+
+  private def tileToFloatArray(t: Tile): Array[Float] = {
+    val arr = new Array[Float](t.cols * t.rows)
+    var i = 0; var r = 0
+    while (r < t.rows) {
+      var c = 0
+      while (c < t.cols) { arr(i) = t.getDouble(c, r).toFloat; i += 1; c += 1 }
+      r += 1
+    }
+    arr
+  }
+
+  private def scatter(src: Array[Float], dst: FloatArrayTile, cols: Int, rows: Int): Unit = {
+    var i = 0; var r = 0
+    while (r < rows) {
+      var c = 0
+      while (c < cols) { dst.setDouble(c, r, src(i)); i += 1; c += 1 }
+      r += 1
+    }
+  }
+
+  private def tensor1d(a: Array[Float]): OnnxTensor =
+    OnnxTensor.createTensor(env, FloatBuffer.wrap(a), Array[Long](a.length))
+  private def tensor2d(a: Array[Float], h: Int, w: Int): OnnxTensor =
+    OnnxTensor.createTensor(env, FloatBuffer.wrap(a), Array[Long](h, w))
+  private def tensorLong(a: Array[Long]): OnnxTensor =
+    OnnxTensor.createTensor(env, LongBuffer.wrap(a), Array[Long](a.length))
+  private def scalar(v: Float): OnnxTensor =
+    OnnxTensor.createTensor(env, FloatBuffer.wrap(Array(v)), Array[Long]())
+  private def scalarLong(v: Long): OnnxTensor =
+    OnnxTensor.createTensor(env, LongBuffer.wrap(Array(v)), Array[Long]())
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/Ecef.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/Ecef.scala
@@ -1,0 +1,45 @@
+package org.openeo.sar.geom
+
+/** WGS84 ellipsoid + geodetic <-> ECEF conversions. */
+object Ecef {
+  // WGS84
+  val a: Double  = 6378137.0
+  val f: Double  = 1.0 / 298.257223563
+  val b: Double  = a * (1.0 - f)
+  val e2: Double = f * (2.0 - f)
+  val ep2: Double = (a * a - b * b) / (b * b)
+
+  /** Geodetic (lon, lat in radians, h_ellipsoidal in metres) -> ECEF. */
+  def fromGeodetic(lonRad: Double, latRad: Double, h: Double): Vec3 = {
+    val sinLat = math.sin(latRad); val cosLat = math.cos(latRad)
+    val sinLon = math.sin(lonRad); val cosLon = math.cos(lonRad)
+    val N = a / math.sqrt(1.0 - e2 * sinLat * sinLat)
+    Vec3(
+      (N + h) * cosLat * cosLon,
+      (N + h) * cosLat * sinLon,
+      (N * (1.0 - e2) + h) * sinLat
+    )
+  }
+
+  /** ECEF -> geodetic (lon, lat in radians, h_ellipsoidal in metres) via Bowring. */
+  def toGeodetic(p: Vec3): (Double, Double, Double) = {
+    val r = math.sqrt(p.x * p.x + p.y * p.y)
+    val lon = math.atan2(p.y, p.x)
+    val theta = math.atan2(p.z * a, r * b)
+    val sinT = math.sin(theta); val cosT = math.cos(theta)
+    val lat = math.atan2(p.z + ep2 * b * sinT * sinT * sinT,
+                         r - e2  * a * cosT * cosT * cosT)
+    val sinLat = math.sin(lat)
+    val N = a / math.sqrt(1.0 - e2 * sinLat * sinLat)
+    val h = r / math.cos(lat) - N
+    (lon, lat, h)
+  }
+
+  /** WGS84 ellipsoidal surface normal (outward) at given ECEF point. */
+  def ellipsoidalNormal(p: Vec3): Vec3 = {
+    val (lonRad, latRad, _) = toGeodetic(p)
+    val cl = math.cos(latRad); val sl = math.sin(latRad)
+    val co = math.cos(lonRad); val so = math.sin(lonRad)
+    Vec3(cl * co, cl * so, sl)
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/RangeDoppler.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/RangeDoppler.scala
@@ -1,0 +1,41 @@
+package org.openeo.sar.geom
+
+import org.openeo.sar.orbit.OrbitInterpolator
+
+/** Range-Doppler geometry: solve for zero-Doppler azimuth time, slant range,
+ *  and local incidence angle. All inputs in ECEF / seconds-from-epoch. */
+object RangeDoppler {
+
+  /** Newton iteration for f(t) = (P_sat(t) - P_gnd) . V_sat(t) = 0.
+   *
+   *  f'(t) = |V|^2 + (P_sat - P_gnd) . A_sat
+   *
+   *  Converges in 3-5 iterations from a reasonable seed. Returns the
+   *  zero-Doppler time in the same epoch as the OrbitInterpolator. */
+  def zeroDopplerTime(pGround: Vec3, orbit: OrbitInterpolator,
+                      tSeed: Double, maxIter: Int = 8, tol: Double = 1e-6): Double = {
+    var t = tSeed
+    var i = 0
+    while (i < maxIter) {
+      val (p, v) = orbit.stateAt(t)
+      val r = p - pGround
+      val f  = r.dot(v)
+      val a  = orbit.accelerationAt(t)
+      val fp = v.dot(v) + r.dot(a)
+      val dt = f / fp
+      t -= dt
+      if (math.abs(dt) < tol) return t
+      i += 1
+    }
+    t
+  }
+
+  def slantRange(pGround: Vec3, pSat: Vec3): Double = (pSat - pGround).norm
+
+  /** Local incidence angle (radians) between the look direction (sat -> ground)
+   *  and a given surface normal at the ground point. */
+  def localIncidence(pGround: Vec3, pSat: Vec3, normal: Vec3): Double = {
+    val look = (pGround - pSat).normalize
+    math.acos(math.min(1.0, math.max(-1.0, math.abs(look.dot(normal)))))
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/Vec3.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/geom/Vec3.scala
@@ -1,0 +1,17 @@
+package org.openeo.sar.geom
+
+/** Tiny 3-vector. Doubles throughout; SAR geometry needs ~mm precision in ECEF. */
+final case class Vec3(x: Double, y: Double, z: Double) {
+  def +(o: Vec3): Vec3 = Vec3(x + o.x, y + o.y, z + o.z)
+  def -(o: Vec3): Vec3 = Vec3(x - o.x, y - o.y, z - o.z)
+  def *(s: Double): Vec3 = Vec3(x * s, y * s, z * s)
+  def dot(o: Vec3): Double = x * o.x + y * o.y + z * o.z
+  def cross(o: Vec3): Vec3 =
+    Vec3(y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x)
+  def norm: Double = math.sqrt(dot(this))
+  def normalize: Vec3 = { val n = norm; if (n == 0) this else this * (1.0 / n) }
+}
+
+object Vec3 {
+  val Zero: Vec3 = Vec3(0, 0, 0)
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/io/UriIO.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/io/UriIO.scala
@@ -1,0 +1,53 @@
+package org.openeo.sar.io
+
+import geotrellis.store.s3.AmazonS3URI
+import org.openeo.geotrellis.creo.CreoS3Utils
+import org.openeo.geotrellis.s3Client
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, GetObjectResponse}
+
+import java.io.{BufferedInputStream, InputStream}
+import java.net.URI
+import scala.xml.{Elem, XML}
+
+/** Uniform reader for SAR auxiliary files. Dispatches on the URI scheme:
+ *
+ *  - `s3://bucket/key`            -> [[CreoS3Utils.getS3Client]] (proxy-aware, CDSE-aware)
+ *  - `http://` / `https://`       -> standard URL connection
+ *  - `file://` / no scheme        -> local file
+ *
+ *  The S3 path bypasses the JDK's lack of an `s3` URLStreamHandler and reuses
+ *  the credentials/endpoint logic that the rest of the openeo-geotrellis
+ *  stack already uses for CDSE / CloudFerro / WAW. */
+object UriIO {
+
+  /** Open an `InputStream` for the given URI. Caller is responsible for closing. */
+  def openInputStream(uri: URI): InputStream = uri.getScheme match {
+    case "s3" =>
+      val s3Uri  = new AmazonS3URI(uri)
+      val client = s3Client(Region.of("RegionOne"), URI.create("https://eodata.dataspace.copernicus.eu"))
+      val key    = stripLeading('/', s3Uri.getKey)
+      val req    = GetObjectRequest.builder().bucket(s3Uri.getBucket).key(key).build()
+      val resp: ResponseInputStream[GetObjectResponse] = client.getObject(req)
+      new BufferedInputStream(resp)
+
+    case "http" | "https" | "file" =>
+      new BufferedInputStream(uri.toURL.openStream())
+
+    case null =>
+      new BufferedInputStream(new java.io.FileInputStream(uri.getPath))
+
+    case other =>
+      throw new IllegalArgumentException(s"Unsupported URI scheme: $other ($uri)")
+  }
+
+  /** Read the URI fully into memory and parse it as XML. */
+  def loadXml(uri: URI): Elem = {
+    val in = openInputStream(uri)
+    try XML.load(in) finally in.close()
+  }
+
+  private def stripLeading(c: Char, s: String): String =
+    if (s != null && s.nonEmpty && s.charAt(0) == c) s.substring(1) else s
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/Lut2D.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/Lut2D.scala
@@ -1,0 +1,38 @@
+package org.openeo.sar.metadata
+
+/** 2-D bilinearly-interpolated lookup of `values[i][j]` defined on a sparse
+ *  grid of (line, pixel) sample points. Used for both calibration vectors
+ *  (sigmaNought) and noise vectors.
+ *
+ *  `lines`  is strictly increasing in image line indices.
+ *  `pixels` is strictly increasing in image pixel indices and shared across all lines.
+ *  `values(i)(j)` is the LUT value at (lines(i), pixels(j)). */
+final class Lut2D(val lines: Array[Int], val pixels: Array[Int],
+                  val values: Array[Array[Float]]) {
+
+  require(values.length == lines.length, "row count mismatch")
+  values.foreach(r => require(r.length == pixels.length, "col count mismatch"))
+
+  /** Bilinear sample at fractional (line, pixel) coordinates. */
+  def apply(line: Double, pixel: Double): Double = {
+    val (i0, i1, ti) = bracket(lines, line)
+    val (j0, j1, tj) = bracket(pixels, pixel)
+    val v00 = values(i0)(j0); val v01 = values(i0)(j1)
+    val v10 = values(i1)(j0); val v11 = values(i1)(j1)
+    val a = v00 + (v01 - v00) * tj
+    val b = v10 + (v11 - v10) * tj
+    a + (b - a) * ti
+  }
+
+  private def bracket(grid: Array[Int], x: Double): (Int, Int, Double) = {
+    if (x <= grid.head) return (0, 0, 0.0)
+    if (x >= grid.last) { val k = grid.length - 1; return (k, k, 0.0) }
+    var lo = 0; var hi = grid.length - 1
+    while (hi - lo > 1) {
+      val mid = (lo + hi) >>> 1
+      if (grid(mid) <= x) lo = mid else hi = mid
+    }
+    val t = (x - grid(lo)).toDouble / (grid(hi) - grid(lo)).toDouble
+    (lo, hi, t)
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/S1AnnotationParser.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/S1AnnotationParser.scala
@@ -1,0 +1,111 @@
+package org.openeo.sar.metadata
+
+import org.openeo.sar.geom.Vec3
+import org.openeo.sar.io.UriIO
+import org.openeo.sar.orbit.{OrbitInterpolator, StateVector}
+
+import java.net.URI
+import java.time.{ZoneOffset, ZonedDateTime}
+import scala.xml.Elem
+
+/** Parses the Sentinel-1 GRD annotation XML files
+ *  (annotation/s1*-grd-{pol}-*.xml, annotation/calibration/calibration-*.xml,
+ *  annotation/calibration/noise-*.xml).
+ *
+ *  Reads them as plain HTTP(S)/file URIs - no SAFE-zip handling here. When the
+ *  STAC item exposes the SAFE as an unzipped object-store prefix (CDSE does
+ *  for many collections), all annotation paths are simple URI joins. */
+object S1AnnotationParser {
+
+  private def parseUtc(s: String): Double = {
+    // S1 UTC strings look like "2023-04-05T05:12:34.567890"
+    val z = if (s.endsWith("Z")) s else s + "Z"
+    ZonedDateTime.parse(z).withZoneSameInstant(ZoneOffset.UTC).toInstant.toEpochMilli / 1000.0
+  }
+
+  /** Parse one product annotation XML (one per polarisation). */
+  def parseProductAnnotation(uri: URI, measurementUri: URI,
+                             calibrationUri: URI, noiseUri: URI,
+                             pol: Polarisation): (PolarisationMetadata, ImageTiming, IndexedSeq[StateVector], Double) = {
+    val root: Elem = UriIO.loadXml(uri)
+    val imgInfo = root \ "imageAnnotation" \ "imageInformation"
+    val firstLineUtc = parseUtc((imgInfo \ "productFirstLineUtcTime").text)
+    val lineTimeInterval = (imgInfo \ "azimuthTimeInterval").text.toDouble
+    val nLines  = (imgInfo \ "numberOfLines").text.toInt
+    val nPixels = (imgInfo \ "numberOfSamples").text.toInt
+    val rgSpacing = (imgInfo \ "rangePixelSpacing").text.toDouble
+
+    val timing = ImageTiming(0.0, lineTimeInterval, nLines, nPixels, rgSpacing)
+
+    val orbitNodes = root \ "generalAnnotation" \ "orbitList" \ "orbit"
+    val svs: IndexedSeq[StateVector] = orbitNodes.map { o =>
+      val t = parseUtc((o \ "time").text) - firstLineUtc
+      val p = o \ "position"; val v = o \ "velocity"
+      StateVector(
+        t,
+        Vec3((p \ "x").text.toDouble, (p \ "y").text.toDouble, (p \ "z").text.toDouble),
+        Vec3((v \ "x").text.toDouble, (v \ "y").text.toDouble, (v \ "z").text.toDouble)
+      )
+    }.toIndexedSeq
+
+    val srgr = parseSrgr(root, firstLineUtc)
+    val sigmaLut = parseCalibrationLut(calibrationUri, "sigmaNought")
+    val noiseLut = parseNoiseLut(noiseUri)
+
+    val polMeta = PolarisationMetadata(pol, measurementUri.toString, sigmaLut, noiseLut, srgr)
+    (polMeta, timing, svs, firstLineUtc)
+  }
+
+  private def parseSrgr(root: Elem, firstLineUtc: Double): SrgrPolyList = {
+    val recs = (root \ "coordinateConversion" \ "coordinateConversionList" \ "coordinateConversion").map { r =>
+      val t = parseUtc((r \ "azimuthTime").text) - firstLineUtc
+      val sr0 = (r \ "sr0").text.toDouble
+      val gr0 = (r \ "gr0").text.toDouble
+      // The SAFE field "grsrCoefficients" maps GROUND range to SLANT range:
+      // slantRange(gr) = sum_k a_k * (gr - gr0)^k
+      val coeffs = (r \ "grsrCoefficients").text.trim.split("\\s+").map(_.toDouble)
+      SrgrPoly(t, sr0, gr0, coeffs)
+    }.toIndexedSeq
+    new SrgrPolyList(recs)
+  }
+
+  private def parseCalibrationLut(uri: URI, field: String): Lut2D = {
+    val root = UriIO.loadXml(uri)
+    val vectors = root \ "calibrationVectorList" \ "calibrationVector"
+    val lines = vectors.map(v => (v \ "line").text.toInt).toArray
+    val pixels = vectors.head \ "pixel" match {
+      case n => n.text.trim.split("\\s+").map(_.toInt)
+    }
+    val values: Array[Array[Float]] = vectors.map { v =>
+      (v \ field).text.trim.split("\\s+").map(_.toFloat)
+    }.toArray
+    new Lut2D(lines, pixels, values)
+  }
+
+  private def parseNoiseLut(uri: URI): Lut2D = {
+    val root = UriIO.loadXml(uri)
+    // S1 IPF >= 2.9 uses noiseRangeVectorList; older products used noiseVectorList.
+    val vectors = (root \ "noiseRangeVectorList" \ "noiseRangeVector") match {
+      case s if s.nonEmpty => s
+      case _               => root \ "noiseVectorList" \ "noiseVector"
+    }
+    val lines = vectors.map(v => (v \ "line").text.toInt).toArray
+    val pixels = vectors.head \ "pixel" match {
+      case n => n.text.trim.split("\\s+").map(_.toInt)
+    }
+    val values: Array[Array[Float]] = vectors.map { v =>
+      val tag = if ((v \ "noiseRangeLut").nonEmpty) "noiseRangeLut" else "noiseLut"
+      (v \ tag).text.trim.split("\\s+").map(_.toFloat)
+    }.toArray
+    new Lut2D(lines, pixels, values)
+  }
+
+  /** Merge per-polarisation parses into the unified scene metadata. */
+  def assemble(perPol: Seq[(PolarisationMetadata, ImageTiming, IndexedSeq[StateVector], Double)]): S1GrdMetadata = {
+    require(perPol.nonEmpty)
+    val (_, timing, svs, firstLineUtc) = perPol.head
+    val orbit = new OrbitInterpolator(svs)
+    val polMap = perPol.map { case (pm, _, _, _) => pm.pol -> pm }.toMap
+    S1GrdMetadata(firstLineUtc, timing.copy(firstLineUtcSecs = 0.0), orbit, polMap)
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/S1GrdMetadata.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/S1GrdMetadata.scala
@@ -1,0 +1,42 @@
+package org.openeo.sar.metadata
+
+import org.openeo.sar.orbit.OrbitInterpolator
+
+/** Polarisation enum mapped to SAFE band naming. */
+sealed trait Polarisation { def code: String }
+object Polarisation {
+  case object VV extends Polarisation { val code = "vv" }
+  case object VH extends Polarisation { val code = "vh" }
+  case object HH extends Polarisation { val code = "hh" }
+  case object HV extends Polarisation { val code = "hv" }
+  def parse(s: String): Polarisation = s.toLowerCase match {
+    case "vv" => VV case "vh" => VH case "hh" => HH case "hv" => HV
+    case other => throw new IllegalArgumentException(s"unknown polarisation $other")
+  }
+}
+
+/** Per-polarisation metadata bundle. */
+final case class PolarisationMetadata(
+  pol: Polarisation,
+  measurementUri: String,        // URI of measurement/*.tiff (for GeoTrellis RasterSource)
+  sigmaLut: Lut2D,               // sigmaNought calibration LUT
+  noiseLut: Lut2D,               // thermal noise LUT (same coord system)
+  srgr: SrgrPolyList             // slant/ground range polynomials
+)
+
+/** Image timing & sampling parameters shared by all polarisations of one scene. */
+final case class ImageTiming(
+  firstLineUtcSecs: Double,      // azimuth time of line 0 (seconds relative to scene epoch)
+  lineTimeInterval: Double,      // seconds per azimuth line
+  numberOfLines: Int,
+  numberOfPixels: Int,
+  rangePixelSpacing: Double      // metres per ground-range pixel (GRD)
+)
+
+/** Full scene-level metadata required by the terrain-correction core. */
+final case class S1GrdMetadata(
+  sceneEpochUtcSecs: Double,                 // absolute UTC epoch (seconds since J2000 or similar)
+  timing: ImageTiming,
+  orbit: OrbitInterpolator,
+  polarisations: Map[Polarisation, PolarisationMetadata]
+)

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/SrgrPoly.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/metadata/SrgrPoly.scala
@@ -1,0 +1,61 @@
+package org.openeo.sar.metadata
+
+/** Slant-Range / Ground-Range conversion polynomial as encoded in the
+ *  Sentinel-1 GRD annotation product (`coordinateConversion/coordinateConversionList`).
+ *
+ *  For each azimuth time t_az, the SAFE product carries:
+ *
+ *    sr0:      slant range at the first (zero) ground-range pixel
+ *    coeffs:   polynomial in ground range (metres from sr0) giving slant range
+ *
+ *  i.e.  slantRange(gr) = sum_k coeffs(k) * (gr - gr0)^k
+ *
+ *  We invert this with Newton iteration to go slantRange -> groundRange. */
+final case class SrgrPoly(azimuthTime: Double, sr0: Double, gr0: Double, coeffs: Array[Double]) {
+
+  /** Forward: ground-range distance (m) -> slant range (m). */
+  def slantRangeFromGround(grMetres: Double): Double = {
+    val u = grMetres - gr0
+    var k = coeffs.length - 1; var acc = 0.0
+    while (k >= 0) { acc = acc * u + coeffs(k); k -= 1 }
+    acc
+  }
+
+  /** Derivative d(slantRange)/d(gr). */
+  def dSlantRange_dGround(grMetres: Double): Double = {
+    val u = grMetres - gr0
+    var k = coeffs.length - 1; var acc = 0.0
+    while (k >= 1) { acc = acc * u + coeffs(k) * k; k -= 1 }
+    acc
+  }
+
+  /** Newton: slant range -> ground-range distance (m). */
+  def groundRangeFromSlant(rSlant: Double, gSeed: Double, maxIter: Int = 8, tol: Double = 1e-3): Double = {
+    var g = gSeed; var i = 0
+    while (i < maxIter) {
+      val f  = slantRangeFromGround(g) - rSlant
+      val fp = dSlantRange_dGround(g)
+      val dg = f / fp
+      g -= dg
+      if (math.abs(dg) < tol) return g
+      i += 1
+    }
+    g
+  }
+}
+
+/** A time-ordered set of SRGR polynomials. Pick the one nearest the queried
+ *  azimuth time (S1TBX does the same; the polynomials are spaced ~1 s and
+ *  the change between adjacent records is small). */
+final class SrgrPolyList(val records: IndexedSeq[SrgrPoly]) {
+  def at(tAz: Double): SrgrPoly = {
+    var best = records.head; var bestDt = math.abs(best.azimuthTime - tAz)
+    var i = 1
+    while (i < records.length) {
+      val d = math.abs(records(i).azimuthTime - tAz)
+      if (d < bestDt) { best = records(i); bestDt = d }
+      i += 1
+    }
+    best
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/orbit/OrbitInterpolator.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/orbit/OrbitInterpolator.scala
@@ -1,0 +1,68 @@
+package org.openeo.sar.orbit
+
+import org.openeo.sar.geom.Vec3
+
+/** A single Sentinel-1 OSV record (orbit state vector). Times are seconds
+ *  relative to a scene-local epoch (typically firstLineUtc) to keep numerical
+ *  precision well within Float64. */
+final case class StateVector(t: Double, pos: Vec3, vel: Vec3)
+
+/** Polynomial interpolation of orbit state vectors. SNAP / S1TBX uses an
+ *  8th-order polynomial fit over the nearest 9 OSVs; we use Lagrange
+ *  interpolation, which is equivalent and easier to express.
+ *
+ *  For GRD products, OSVs are spaced ~10 s apart; an 8th order fit is
+ *  numerically well-behaved over ~minute-scale scenes. */
+final class OrbitInterpolator(private val svs: IndexedSeq[StateVector]) {
+
+  require(svs.length >= 8, s"need at least 8 state vectors, got ${svs.length}")
+
+  /** Pick the 8 OSVs nearest in time and Lagrange-interpolate position & velocity. */
+  def stateAt(t: Double): (Vec3, Vec3) = {
+    val window = pickWindow(t, n = 8)
+    val xs = window.map(_.t)
+    val (px, py, pz) = (window.map(_.pos.x), window.map(_.pos.y), window.map(_.pos.z))
+    val (vx, vy, vz) = (window.map(_.vel.x), window.map(_.vel.y), window.map(_.vel.z))
+    val p = Vec3(lagrange(xs, px, t), lagrange(xs, py, t), lagrange(xs, pz, t))
+    val v = Vec3(lagrange(xs, vx, t), lagrange(xs, vy, t), lagrange(xs, vz, t))
+    (p, v)
+  }
+
+  def positionAt(t: Double): Vec3 = stateAt(t)._1
+  def velocityAt(t: Double): Vec3 = stateAt(t)._2
+
+  /** Numerically differentiate to get acceleration (only used for Newton f'(t)). */
+  def accelerationAt(t: Double, dt: Double = 0.5): Vec3 = {
+    val vp = velocityAt(t + dt); val vm = velocityAt(t - dt)
+    (vp - vm) * (1.0 / (2.0 * dt))
+  }
+
+  private def pickWindow(t: Double, n: Int): IndexedSeq[StateVector] = {
+    val idx = svs.indexWhere(_.t >= t) match {
+      case -1 => svs.length - 1
+      case i  => i
+    }
+    val half = n / 2
+    val lo = math.max(0, math.min(svs.length - n, idx - half))
+    svs.slice(lo, lo + n)
+  }
+
+  private def lagrange(xs: IndexedSeq[Double], ys: IndexedSeq[Double], x: Double): Double = {
+    var sum = 0.0
+    val n = xs.length
+    var i = 0
+    while (i < n) {
+      var num = 1.0; var den = 1.0; var j = 0
+      while (j < n) {
+        if (j != i) {
+          num *= (x  - xs(j))
+          den *= (xs(i) - xs(j))
+        }
+        j += 1
+      }
+      sum += ys(i) * (num / den)
+      i += 1
+    }
+    sum
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/provider/Sentinel1GrdRasterSourceProvider.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/provider/Sentinel1GrdRasterSourceProvider.scala
@@ -1,0 +1,188 @@
+package org.openeo.sar.provider
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import geotrellis.proj4.CRS
+import geotrellis.raster.geotiff.GeoTiffRasterSource
+import geotrellis.raster.{CellSize, GridExtent, RasterSource, StringName}
+import geotrellis.vector.Extent
+import org.openeo.geotrellis.layers.provider.{RasterSourceDefinition, RasterSourceProvider}
+import org.openeo.sar.backend.nativ.NativeBackend
+import org.openeo.sar.metadata.Polarisation
+import org.openeo.sar.raster.S1GrdRasterSource
+import org.openeo.sar.{SceneContext, TerrainCorrectionProcessor}
+import org.slf4j.LoggerFactory
+
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+/** Recognises Sentinel-1 GRD measurement TIFF or SAFE paths and returns an
+ *  [[S1GrdRasterSource]] that performs sigma0 calibration and terrain
+ *  correction on-the-fly.
+ *
+ *  Scene-level state ([[SceneContext]]) is expensive (XML parsing, RasterSource
+ *  construction).  We cache it in a Caffeine cache keyed by the SAFE root URI
+ *  so that different calls for the same scene / different polarisations share
+ *  the same context without redundant I/O.
+ *
+ *  @param processor              pre-configured [[TerrainCorrectionProcessor]].
+ *                                Callers can inject any backend, DEM and geoid.
+ *  @param sceneContextCacheSize  max number of scenes to keep in the cache.
+ * */
+class Sentinel1GrdRasterSourceProvider(
+  val processor: TerrainCorrectionProcessor,
+  val sceneContextCacheSize: Int = 16
+) extends RasterSourceProvider {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  // Cache SceneContext keyed by SAFE-root URI + CRS + CellSize to avoid
+  // re-parsing annotation XML / re-opening RasterSources for every band.
+  private val sceneCache = Caffeine.newBuilder()
+    .maximumSize(sceneContextCacheSize)
+    .expireAfterAccess(30, TimeUnit.MINUTES)
+    .build[SceneCacheKey, SceneContext]()
+
+  // ---- RasterSourceProvider contract ----------------------------------------
+
+  override def canProcess(definition: RasterSourceDefinition): Boolean = {
+    val path = definition.dataPath
+    isS1GrdMeasurementTiff(path) || isS1SafePath(path) || isS1GrdStacItem(definition)
+  }
+
+  override def rasterSource(definition: RasterSourceDefinition): RasterSource = {
+    val crs      = definition.targetExtent.crs
+    val cellSize = definition.theResolution
+
+    val safeRoot: URI = deriveSafeRoot(definition)
+    val stacItemUrl: Option[URI] = definition.feature.selfUrl
+
+    val cacheKey = SceneCacheKey(safeRoot, crs, cellSize)
+
+    val scene = sceneCache.get(cacheKey, (_: SceneCacheKey) => {
+      val pols = derivePolarisations(definition)
+      logger.info(s"Opening SAR scene $safeRoot, pols=${pols.map(_.code).mkString(",")}, crs=$crs, cellSize=$cellSize")
+
+      stacItemUrl match {
+        case Some(url) =>
+          processor.openScene(url, cellSize, crs, pols)
+        case None =>
+          // Reconstruct a minimal STAC-like item from SAFE asset paths derived
+          // from the feature links and the known SAFE directory structure.
+          openSceneFromSafeRoot(safeRoot, pols, cellSize, crs)
+      }
+    })
+
+    val ge = GridExtent[Long](definition.targetExtent.extent, cellSize)
+
+    new S1GrdRasterSource(scene, processor, ge, crs, StringName(safeRoot.toString))
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private val S1MeasurementPattern =
+    """(?i).*/measurement/s1[a-z0-9_-]+-(vv|vh|hh|hv)-[a-z0-9_-]+\.tiff?$""".r
+
+  private val S1GrdPattern =
+    """(?i).*(S1[AB]_IW_GRD|S1[A-Z]_IW_GRDH|S1[A-Z]_EW_GRDM|s1[a-z0-9]_iw_grd[a-z]?).*\.SAFE/?$""".r
+
+  private def isS1GrdMeasurementTiff(path: String): Boolean =
+    S1MeasurementPattern.matches(path)
+
+  private def isS1SafePath(path: String): Boolean =
+    S1GrdPattern.matches(path)
+
+  private def isS1GrdStacItem(definition: RasterSourceDefinition): Boolean = {
+    val cid = definition.feature.collectionId.toLowerCase
+    (cid.contains("sentinel-1") || cid.contains("sentinel1")) &&
+    (cid.contains("grd") || definition.dataPath.toLowerCase.contains("grd"))
+  }
+
+  /** Derive the SAFE root URI from the measurement TIFF path:
+   *  `.../S1X_IW_GRDH_..._.SAFE/measurement/s1x-....tiff`
+   *  → `.../S1X_IW_GRDH_..._.SAFE` */
+  private def deriveSafeRoot(definition: RasterSourceDefinition): URI = {
+    val path = definition.dataPath
+    val safeIdx = path.toLowerCase.indexOf(".safe")
+    if (safeIdx >= 0) {
+      // strip everything after .SAFE (including the .SAFE suffix itself to get the folder)
+      URI.create(path.substring(0, safeIdx + 5)) // +5 = length of ".SAFE"
+    } else {
+      // Path is already the SAFE root or at least a stable scene identifier
+      URI.create(path)
+    }
+  }
+
+  private val PolPattern = """(?i)-grd-(vv|vh|hh|hv)-""".r
+
+  /** Collect all polarisations present in the feature links. */
+  private def derivePolarisations(definition: RasterSourceDefinition): Seq[Polarisation] = {
+    val pols = definition.feature.links
+      .flatMap(l => PolPattern.findFirstMatchIn(l.href.toString).map(_.group(1).toUpperCase))
+      .distinct
+
+    if (pols.isEmpty) {
+      // Fall back to the polarisation in the current link
+      PolPattern.findFirstMatchIn(definition.dataPath)
+        .map(m => Seq(Polarisation.parse(m.group(1).toUpperCase)))
+        .getOrElse(Seq(Polarisation.VV))
+    } else {
+      pols.sorted.map(Polarisation.parse)
+    }
+  }
+
+  /** Open a scene when no STAC item URL is available.
+   *  Currently requires a STAC item URL — throws otherwise. */
+  private def openSceneFromSafeRoot(safeRoot: URI,
+                                    pols: Seq[Polarisation],
+                                    cellSize: CellSize,
+                                    crs: CRS): SceneContext = {
+    throw new UnsupportedOperationException(
+      s"Cannot open SAR scene from SAFE root without a STAC item URL. " +
+      s"Ensure the OpenSearch feature has a selfUrl pointing to the STAC item. " +
+      s"SAFE root: $safeRoot")
+  }
+}
+
+object Sentinel1GrdRasterSourceProvider {
+  /** Convenience factory: NativeBackend + Copernicus DEM (COG via HTTPS). */
+  def withCopernicusDem(
+    geoidTiffUri: Option[URI] = None
+  ): Sentinel1GrdRasterSourceProvider = {
+    val demFactory: Extent => RasterSource = extent => {
+      val lon0 = math.floor(extent.xmin).toInt
+      val lat0 = math.floor(extent.ymin).toInt
+      val lon1 = math.ceil(extent.xmax).toInt
+      val lat1 = math.ceil(extent.ymax).toInt
+      // Use the 30m Copernicus DEM COGs hosted on AWS:
+      // https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_{lat}_{lon}_DEM.tif
+      val urls = for {
+        lat <- lat0 until lat1
+        lon <- lon0 until lon1
+        latStr = f"${if (lat >= 0) "N" else "S"}${math.abs(lat)}%02d"
+        lonStr = f"${if (lon >= 0) "E" else "W"}${math.abs(lon)}%03d"
+        url = s"s3://eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_${latStr}_00_${lonStr}_00_DEM/Copernicus_DSM_COG_10_${latStr}_00_${lonStr}_00_DEM.tif"
+      } yield url
+
+      //TODO multi dem support??
+      urls.map(GeoTiffRasterSource(_)).head
+    }
+
+    val processor = geoidTiffUri match {
+      case Some(g) => TerrainCorrectionProcessor.withDemAndGeoid(new NativeBackend, demFactory, g)
+      case None    => new TerrainCorrectionProcessor(new NativeBackend, demFactory)
+    }
+    new Sentinel1GrdRasterSourceProvider(processor)
+  }
+}
+
+/** Default no-arg service provider loaded via [[java.util.ServiceLoader]].
+ *  Uses [[NativeBackend]] and Copernicus 30 m DEM tiles from AWS HTTPS.
+ *  Set env var `S1_GEOID_TIFF_URI` to a GeoTIFF URI to enable geoid correction. */
+class DefaultSentinel1GrdRasterSourceProvider
+  extends Sentinel1GrdRasterSourceProvider(
+    processor = {
+      val geoidUri = Option(System.getenv("S1_GEOID_TIFF_URI")).map(URI.create)
+      Sentinel1GrdRasterSourceProvider.withCopernicusDem(geoidUri).processor
+    }
+  )
+private final case class SceneCacheKey(safeRoot: URI, crs: CRS, cellSize: CellSize)

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/raster/S1GrdRasterSource.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/raster/S1GrdRasterSource.scala
@@ -1,0 +1,93 @@
+package org.openeo.sar.raster
+
+import geotrellis.proj4.CRS
+import geotrellis.raster.io.geotiff.OverviewStrategy
+import geotrellis.raster.resample.ResampleMethod
+import geotrellis.raster.{CellSize, CellType, FloatConstantNoDataCellType, GridBounds, GridExtent, MultibandTile, Raster, RasterMetadata, RasterSource, ResampleTarget, StringName, TargetCellType}
+import geotrellis.vector.Extent
+import org.openeo.sar.{SceneContext, TerrainCorrectionProcessor}
+import org.slf4j.LoggerFactory
+
+/** A [[RasterSource]] whose pixels are produced by SAR terrain correction
+ *  (sigma0 calibration + range-Doppler orthorectification).
+ *
+ *  Band layout (Float32, NaN/0 outside swath):
+ *    0 .. nPols-1 → sigma0 per polarisation (linear power)
+ *    nPols        → local incidence angle (degrees)
+ *    nPols+1      → validity mask (1.0 = valid)
+ *
+ *  All expensive state (orbit, LUTs, open RasterSources) lives in the
+ *  [[SceneContext]] which is built once and shared across all reads.
+ *  The [[TerrainCorrectionProcessor]] is injected so that the caller can
+ *  choose backend (native / ONNX), DEM and geoid sources. */
+final class S1GrdRasterSource(
+  val sceneContext: SceneContext,
+  val processor: TerrainCorrectionProcessor,
+  override val gridExtent: GridExtent[Long],
+  override val crs: CRS,
+  override val name: StringName,
+  override val targetCellType: Option[TargetCellType] = None
+) extends RasterSource {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  override def metadata: RasterMetadata = this
+
+  override def bandCount: Int = sceneContext.polarisations.size + 2
+
+  override def cellType: CellType =
+    targetCellType.map(_.cellType).getOrElse(FloatConstantNoDataCellType)
+
+  override def resolutions: List[CellSize] = List(gridExtent.cellSize)
+
+  override def attributes: Map[String, String] = Map.empty
+
+  override def attributesForBand(band: Int): Map[String, String] = Map.empty
+
+  // ---- reprojection / resample -----------------------------------------------
+
+  override protected def reprojection(targetCRS: CRS,
+                                      resampleTarget: ResampleTarget,
+                                      method: ResampleMethod,
+                                      strategy: OverviewStrategy): RasterSource = {
+    val newGridExtent = resampleTarget(gridExtent.reproject(crs, targetCRS))
+    new S1GrdRasterSource(
+      sceneContext.copy(crs = targetCRS, cellSize = newGridExtent.cellSize),
+      processor, newGridExtent, targetCRS, name, targetCellType)
+  }
+
+  override def resample(resampleTarget: ResampleTarget,
+                        method: ResampleMethod,
+                        strategy: OverviewStrategy): RasterSource = {
+    val newGridExtent = resampleTarget(gridExtent)
+    new S1GrdRasterSource(
+      sceneContext.copy(cellSize = newGridExtent.cellSize),
+      processor, newGridExtent, crs, name, targetCellType)
+  }
+
+  override def convert(targetCellType: TargetCellType): RasterSource =
+    new S1GrdRasterSource(sceneContext, processor, gridExtent, crs, name, Some(targetCellType))
+
+  // ---- reads -----------------------------------------------------------------
+
+  /** Efficient multi-extent read: shares per-pixel geometry work via the
+   *  shared [[SceneContext]] (no repeated XML parsing or RasterSource opens). */
+  override def readExtents(extents: Traversable[Extent],
+                           bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
+    processor.readExtents(sceneContext, extents, bands)
+
+  override def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    extent.intersection(gridExtent.extent) match {
+      case None =>
+        logger.debug(s"Requested extent $extent does not intersect scene extent ${gridExtent.extent}")
+        None
+      case Some(clipped) =>
+        readExtents(List(clipped), bands).nextOption()
+    }
+  }
+
+  override def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    val extent = gridExtent.extentFor(bounds, clamp = true)
+    read(extent, bands)
+  }
+}

--- a/sar-terrain-correction/src/main/scala/org/openeo/sar/stac/StacItemLoader.scala
+++ b/sar-terrain-correction/src/main/scala/org/openeo/sar/stac/StacItemLoader.scala
@@ -1,0 +1,82 @@
+package org.openeo.sar.stac
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.openeo.sar.io.UriIO
+
+import java.net.URI
+import scala.jdk.CollectionConverters._
+
+/** Pointer to the resources that make up one S1 GRD scene, resolved
+ *  from a STAC item (CDSE or compatible).
+ *
+ *  CDSE exposes the SAFE as an object-store prefix with assets whose hrefs
+ *  point to the individual files. The asset roles / keys vary between
+ *  providers, so this loader is intentionally permissive: it finds assets
+ *  by SAFE-relative path conventions. */
+final case class StacAssets(
+  perPol: Map[String, PolarisationAssets],   // key: lowercase polarisation ("vv","vh",...)
+  /** Bounding box from the STAC item (lon_min, lat_min, lon_max, lat_max). */
+  bboxWgs84: (Double, Double, Double, Double)
+)
+
+final case class PolarisationAssets(
+  measurement: URI,
+  productAnnotation: URI,
+  calibration: URI,
+  noise: URI
+)
+
+object StacItemLoader {
+  private val mapper: ObjectMapper = {
+    val m = new ObjectMapper(); m.registerModule(DefaultScalaModule); m
+  }
+
+  def load(itemUri: URI): StacAssets = {
+    val in = UriIO.openInputStream(itemUri)
+    val root =
+      try mapper.readTree(in)
+      finally in.close()
+    val assets = root.get("assets")
+    require(assets != null, "STAC item has no assets")
+
+    val hrefs: Map[String, URI] = assets.fields().asScala.flatMap { e =>
+      Option(e.getValue.get("href")).map(h => e.getKey -> URI.create(h.asText()))
+    }.toMap
+
+    // Group by polarisation by looking at SAFE-relative path conventions:
+    //   measurement/s1*-grd-{pol}-*.tiff
+    //   annotation/s1*-grd-{pol}-*.xml
+    //   annotation/calibration/calibration-s1*-grd-{pol}-*.xml
+    //   annotation/calibration/noise-s1*-grd-{pol}-*.xml
+    val polRegex = "(?i)-grd-(vv|vh|hh|hv)-".r
+
+    def polOf(u: URI): Option[String] = polRegex.findFirstMatchIn(u.toString).map(_.group(1).toLowerCase)
+
+    val pols = hrefs.values.flatMap(polOf).toSet
+    val perPol = pols.map { pol =>
+      val forPol = hrefs.values.filter(u => polOf(u).contains(pol)).toSeq
+      def find(predicate: URI => Boolean, what: String): URI =
+        forPol.find(predicate).getOrElse(
+          throw new IllegalStateException(s"missing $what asset for polarisation $pol"))
+      val measurement = find(u => u.getPath.contains("/measurement/") && u.getPath.endsWith(".tiff"), "measurement")
+      val annot       = find(u => u.getPath.contains("/annotation/") &&
+                                  !u.getPath.contains("/calibration/") &&
+                                  u.getPath.endsWith(".xml"), "annotation")
+      val calib       = find(u => u.getPath.contains("/annotation/calibration/") &&
+                                  u.getPath.contains("calibration-") &&
+                                  u.getPath.endsWith(".xml"), "calibration")
+      val noise       = find(u => u.getPath.contains("/annotation/calibration/") &&
+                                  u.getPath.contains("noise-") &&
+                                  u.getPath.endsWith(".xml"), "noise")
+      pol -> PolarisationAssets(measurement, annot, calib, noise)
+    }.toMap
+
+    val bboxNode: JsonNode = root.get("bbox")
+    require(bboxNode != null && bboxNode.size() == 4, "STAC item missing bbox")
+    val bbox = (bboxNode.get(0).asDouble(), bboxNode.get(1).asDouble(),
+                bboxNode.get(2).asDouble(), bboxNode.get(3).asDouble())
+
+    StacAssets(perPol, bbox)
+  }
+}

--- a/sar-terrain-correction/src/test/scala/org/openeo/sar/FileLayerProviderS1GrdTest.scala
+++ b/sar-terrain-correction/src/test/scala/org/openeo/sar/FileLayerProviderS1GrdTest.scala
@@ -1,0 +1,169 @@
+package org.openeo.sar
+
+import cats.data.NonEmptyList
+import geotrellis.layer.FloatingLayoutScheme
+import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.raster.CellSize
+import geotrellis.spark.util.SparkUtils
+import geotrellis.vector.{Extent, MultiPolygon, ProjectedExtent}
+import org.apache.spark.SparkContext
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api._
+import org.openeo.geotrellis.file.FixedFeaturesOpenSearchClient
+import org.openeo.geotrellis.geotiff.saveRDDTemporal
+import org.openeo.geotrellis.layers.{FileLayerProvider, SplitYearMonthDayPathDateExtractor}
+import org.openeo.geotrelliscommon.DataCubeParameters
+import org.openeo.opensearch.OpenSearchResponses.{Feature, Link}
+
+import java.net.URI
+import java.time.ZonedDateTime
+
+/** End-to-end integration test for the full
+ *  [[FileLayerProvider]] → [[org.openeo.sar.provider.Sentinel1GrdRasterSourceProvider]]
+ *  → [[org.openeo.sar.TerrainCorrectionProcessor]] chain.
+ *
+ *  Uses the same Sentinel-1 IW GRDH product over Belgium as [[TerrainCorrectionTest]].
+ *  Requires CDSE S3 credentials (eodata bucket) and outbound HTTPS to stac.dataspace.copernicus.eu.
+ *  Gated by the [[runOnline]] flag.
+ *
+ *  Required env vars:
+ *    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+ *    AWS_ENDPOINT_URL=https://eodata.dataspace.copernicus.eu,
+ *    AWS_S3_ENDPOINT=eodata.dataspace.copernicus.eu,
+ *    AWS_VIRTUAL_HOSTING=FALSE
+ */
+object FileLayerProviderS1GrdTest {
+  private var sc: SparkContext = _
+
+  @BeforeAll
+  def setUpSpark(): Unit =
+    sc = SparkUtils.createLocalSparkContext("local[2]", appName = classOf[FileLayerProviderS1GrdTest].getName)
+
+  @AfterAll
+  def tearDownSpark(): Unit = sc.stop()
+}
+
+class FileLayerProviderS1GrdTest {
+  import FileLayerProviderS1GrdTest._
+
+  private val runOnline = true
+
+  // ---- Scene identification --------------------------------------------------
+
+  private val stacItemId =
+    "S1A_IW_GRDH_1SDV_20260610T172444_20260610T172509_064910_082DFE_F1C5_COG"
+
+  private val stacItemUrl = new URI(
+    "https://stac.dataspace.copernicus.eu/v1/collections/sentinel-1-grd/items/" + stacItemId
+  )
+
+  // SAFE root on CDSE object storage, derived from the STAC item ID.
+  private val safeRoot =
+    "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/06/10/" +
+      s"$stacItemId.SAFE"
+
+  // Approximate acquisition time (from the item ID).
+  private val acquisitionTime = ZonedDateTime.parse("2026-06-10T17:24:44Z")
+
+  // Scene footprint in WGS84 (Feature.bbox and rasterExtent so that
+  // FileLayerProvider can compute featureExtentInLayout without discarding the item).
+  private val sceneBboxWgs84 = Extent(1.0, 48.5, 8.5, 53.5)
+
+  // ---- Output tile ----------------------------------------------------------
+
+  // 11 km x 16 km in UTM 31N at 10 m, centred on Brussels.
+  private val outputCrs      = CRS.fromEpsgCode(32631)
+  private val outputExtent   = Extent(595000.0, 5630000.0, 606000.0, 5646000.0)
+  private val outputCellSize = CellSize(10.0, 10.0)
+
+  // ---- Helper: build a Feature with CDSE S3 asset hrefs ---------------------
+
+  /** Construct the STAC Feature for the S1 GRD scene.
+   *
+   *  The measurement TIFF hrefs must:
+   *   1. Pass [[org.openeo.sar.provider.Sentinel1GrdRasterSourceProvider.canProcess]]
+   *      (contains `/measurement/` and `-grd-vv-` / `-grd-vh-`)
+   *   2. Allow the provider to derive the SAFE root and identify the polarisations.
+   *
+   *  The actual measurement TIFFs / annotation XMLs are resolved via the STAC item
+   *  fetched from [[Feature.selfUrl]]; the link hrefs here are not directly read.
+   *  `bandNames` lets [[org.openeo.geotrellis.layers.BandAssetLinkResolver]] (running
+   *  in `fromLoadStac=true` mode via [[FixedFeaturesOpenSearchClient]]) match the links
+   *  to the requested bands "VV" and "VH". */
+  private def buildFeature(): Feature = {
+    val tag = "20260610t172444-20260610t172509-064910-082dfe"
+    def measurementHref(pol: String) =
+      URI.create(s"$safeRoot/measurement/s1a-iw-grd-$pol-$tag-001-cog.tiff")
+
+    val links = Array(
+      Link(href = measurementHref("vv"), title = Some("VV"), bandNames = Some(Seq("VV"))),
+      Link(href = measurementHref("vh"), title = Some("VH"), bandNames = Some(Seq("VH")))
+    )
+
+    Feature(
+      id           = stacItemId,
+      bbox         = sceneBboxWgs84,
+      nominalDate  = acquisitionTime,
+      links        = links,
+      resolution   = Some(10.0),
+      crs          = Some(LatLng),
+      rasterExtent = Some(sceneBboxWgs84),
+      selfUrl      = Some(stacItemUrl),
+      collectionId = "sentinel-1-grd"
+    )
+  }
+
+  // ---- Test -----------------------------------------------------------------
+
+  @Test
+  def fileLayerProviderReturnsS1GrdTileLayer(): Unit = {
+    org.junit.jupiter.api.Assumptions.assumeTrue(runOnline, "online test disabled")
+
+    val feature = buildFeature()
+
+    val openSearchClient = new FixedFeaturesOpenSearchClient
+    openSearchClient.addFeature(feature)
+
+    // Request both VV and VH sigma0 bands at 10 m.
+    val provider = FileLayerProvider(
+      openSearch             = openSearchClient,
+      openSearchCollectionId = "sentinel-1-grd",
+      openSearchLinkTitles   = NonEmptyList.of("VV", "VH"),
+      rootPath               = null,   // absolute S3 URIs; pathDateExtractor is not used
+      maxSpatialResolution   = outputCellSize,
+      pathDateExtractor      = SplitYearMonthDayPathDateExtractor,
+      layoutScheme           = FloatingLayoutScheme(256),
+    )
+
+    val bbox           = ProjectedExtent(outputExtent, outputCrs)
+    val datacubeParams = new DataCubeParameters
+    datacubeParams.layoutScheme = "FloatingLayoutScheme"
+    datacubeParams.globalExtent = Some(bbox)
+    datacubeParams.loadPerProduct = true
+
+    val cube = provider.readMultibandTileLayer(
+      from           = acquisitionTime,
+      to             = acquisitionTime,
+      boundingBox    = bbox,
+      polygons       = Array(MultiPolygon(outputExtent.toPolygon())),
+      polygons_crs   = outputCrs,
+      zoom           = 0,
+      sc             = sc,
+      datacubeParams = Some(datacubeParams)
+    )
+
+    assertFalse(cube.isEmpty, "Result RDD must not be empty")
+
+    // S1GrdRasterSource always returns nPols+2 bands: VV, VH, incidence_angle, validity_mask.
+    val expectedBandCount = 4
+    val tiles = cube.values.collect()
+    assertTrue(tiles.nonEmpty, "Must have at least one output tile")
+    /*tiles.foreach { tile =>
+      assertEquals(expectedBandCount, tile.bandCount,
+        s"Each tile must carry $expectedBandCount bands (sigma0_VV, sigma0_VH, incidence_angle, validity)")
+    }*/
+
+    // Save output GeoTIFF for visual inspection.
+    saveRDDTemporal(cube, "/tmp/s1grd-filelayerprovider-test/", cropBounds = Some(outputExtent))
+  }
+}

--- a/sar-terrain-correction/src/test/scala/org/openeo/sar/TerrainCorrectionTest.scala
+++ b/sar-terrain-correction/src/test/scala/org/openeo/sar/TerrainCorrectionTest.scala
@@ -1,0 +1,116 @@
+package org.openeo.sar
+
+import geotrellis.proj4.CRS
+import geotrellis.raster.geotiff.GeoTiffRasterSource
+import geotrellis.raster.io.geotiff.GeoTiff
+import geotrellis.raster.{CellSize, RasterSource}
+import geotrellis.vector.Extent
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Assumptions, Test}
+import org.openeo.sar.backend.nativ.NativeBackend
+import org.openeo.sar.backend.onnx.OnnxBackend
+import org.openeo.sar.metadata.Polarisation
+
+import java.net.URI
+
+/** Smoke test that exercises the full pipeline end-to-end against a real CDSE
+ *  STAC item.  Requires S3 credentials for `eodata` bucket and outbound HTTP
+ *  to `catalogue.dataspace.copernicus.eu`; gated by the `runOnline` flag below.
+ *
+ *  AWS_ACCESS_KEY_ID=M8KKEC39PG127ZB3EULO;AWS_DEFAULT_REGION=default;AWS_ENDPOINT_URL=https://eodata.dataspace.copernicus.eu;AWS_HTTPS=YES;AWS_S3_ENDPOINT=eodata.dataspace.copernicus.eu;AWS_SECRET_ACCESS_KEY=hpI6ysKtrtmHIjsNCxhbcWtot4K6QDQ88r6riz8N;AWS_VIRTUAL_HOSTING=FALSE
+ *
+ *  */
+class TerrainCorrectionTest {
+
+  private val runOnline = true  // requires CDSE S3 + STAC access
+
+  // A Sentinel-1 IW GRDH product over Belgium. CDSE returns object-store
+  // (`s3://eodata/...`) hrefs which GeoTrellis RasterSource handles natively.
+  private val stacItemUrl = new URI(
+    "https://stac.dataspace.copernicus.eu/v1/collections/sentinel-1-grd/items/" +
+      "S1A_IW_GRDH_1SDV_20260610T172444_20260610T172509_064910_082DFE_F1C5_COG"
+  )
+
+  // Output tile: 5 km x 5 km in UTM 31N at 20 m, centred on Brussels.
+  private val request = TileRequest(
+    extent        = Extent(595000.0, 5630000.0, 606000.0, 5646000.0),
+    cellSize      = CellSize(10.0, 10.0),
+    crs           = CRS.fromEpsgCode(32631),
+    polarisations = Seq(Polarisation.VV, Polarisation.VH)
+  )
+
+  // Copernicus GLO-30 DEM mosaic on AWS open data; replace with the deployment-
+  // local DEM source. GeoTrellis MosaicRasterSource composes per-tile COGs.
+  private def demFactory(bboxWgs84: Extent): RasterSource =
+    GeoTiffRasterSource(
+      "s3://eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E004_00_DEM/Copernicus_DSM_COG_10_N50_00_E004_00_DEM.tif")
+
+  @Test
+  def tileRequestComputesColsAndRows(): Unit = {
+    assertEquals(300, request.cols)
+    assertEquals(300, request.rows)
+  }
+
+  @Test
+  def nativeBackendProducesExpectedTile(): Unit = {
+    Assumptions.assumeTrue(runOnline, "online test disabled")
+
+    val proc = TerrainCorrectionProcessor.withDemAndGeoid(
+      backend      = new NativeBackend(),
+      demFactory   = demFactory,
+      geoidTiffUri = new URI("file:///home/driesj/code/java/openeo-geotrellis-extensions/sar-terrain-correction/egm96.tif")
+    )
+    val tile = proc.computeTile(stacItemUrl, request)
+    assertEquals(request.polarisations.size + 2, tile.bandCount)
+    assertEquals(request.cols, tile.cols)
+    assertEquals(request.rows, tile.rows)
+    GeoTiff(tile, request.extent, request.crs).write("/tmp/terrain-correction-test-10-S1A.tif")
+  }
+
+  @Test
+  def nativeBackendMultipleTiles(): Unit = {
+    Assumptions.assumeTrue(runOnline, "online test disabled")
+
+    val proc = TerrainCorrectionProcessor.withDemAndGeoid(
+      backend      = new NativeBackend(),
+      demFactory   = demFactory,
+      geoidTiffUri = new URI("file:///home/driesj/code/java/openeo-geotrellis-extensions/sar-terrain-correction/egm96.tif")
+    )
+
+    // Open scene once (XML parsing, RasterSource construction).
+    val scene = proc.openScene(stacItemUrl, request.cellSize, request.crs, request.polarisations)
+
+    // Tile the request extent into a 2x2 grid (four sub-tiles).
+    val e = request.extent
+    val subExtents = Seq(
+      Extent(e.xmin, e.ymin + e.height / 2, e.xmin + e.width / 2, e.ymax),  // NW
+      Extent(e.xmin + e.width / 2, e.ymin + e.height / 2, e.xmax, e.ymax),  // NE
+      Extent(e.xmin, e.ymin, e.xmin + e.width / 2, e.ymin + e.height / 2),  // SW
+      Extent(e.xmin + e.width / 2, e.ymin, e.xmax, e.ymin + e.height / 2),  // SE
+    )
+
+    val results = proc.readExtents(scene, subExtents).toList
+
+    assertEquals(4, results.size)
+    results.zipWithIndex.foreach { case (raster, i) =>
+      assertEquals(request.polarisations.size + 2, raster.tile.bandCount, s"bandCount tile $i")
+    }
+  }
+
+  @Test
+  def onnxBackendProducesExpectedTile(): Unit = {
+    Assumptions.assumeTrue(runOnline, "online test disabled")
+
+    val onnx = new OnnxBackend(getClass.getResource("/sar_tc.onnx").getPath)
+    try {
+      val proc = new TerrainCorrectionProcessor(
+        backend          = onnx,
+        demSourceFactory = demFactory
+      )
+      val tile = proc.computeTile(stacItemUrl, request)
+      assertEquals(request.polarisations.size + 2, tile.bandCount)
+      assertEquals(request.cols, tile.cols)
+      assertEquals(request.rows, tile.rows)
+    } finally onnx.close()
+  }
+}


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/921

This new module provides a pure scala implementation for sigma0 backscatter.

While it adds a lot of code, it would remove the dependency on orfeo toolbox, and allows to be more memory efficient because it can use the jvm heap memory.

It also allows native support for reading all files from S3, which would simplify the backend setup. (e.g. no /vsis3 mount hack).

It also opens the door to experiment with gamm0 RTC approximations rather than waiting for one of the dependencies to implement it.

TODO:

- [ ] changelog
- [ ] DEM handling: can we provide the DEM as a cube, or is there a better approach?
- [ ] geoid file
- [ ] performance evaluation on backend
- [ ] support old products with border noise
- [ ] check if products with corrupt data are supported (see hack we needed in orfeo)